### PR TITLE
Updated find module proceedures

### DIFF
--- a/cmake/CommonFindMacros.cmake
+++ b/cmake/CommonFindMacros.cmake
@@ -1,0 +1,21 @@
+# Setup restricted search paths
+macro(setup_find_root_context PKG)
+  if(${PKG}_ROOT)
+    set(_CMAKE_FIND_ROOT_PATH "${CMAKE_FIND_ROOT_PATH}")
+    set(_CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
+    set(CMAKE_FIND_ROOT_PATH "${${PKG}_ROOT}")
+    set(CMAKE_PREFIX_PATH /)
+    set(_${PKG}_FIND_OPTS ${${PKG}_FIND_OPTS})
+    set(${PKG}_FIND_OPTS ONLY_CMAKE_FIND_ROOT_PATH ${${PKG}_FIND_OPTS})
+  endif()
+endmacro()
+
+
+# Restore original search paths
+macro(restore_find_root_context PKG)
+  if(${PKG}_ROOT)
+    set(CMAKE_FIND_ROOT_PATH "${_CMAKE_FIND_ROOT_PATH}")
+    set(CMAKE_PREFIX_PATH "${_CMAKE_PREFIX_PATH}")
+    set(${PKG}_FIND_OPTS ${_${PKG}_FIND_OPTS})
+  endif()
+endmacro()

--- a/cmake/FindPROJ.cmake
+++ b/cmake/FindPROJ.cmake
@@ -16,14 +16,12 @@
 if(PROJ_DIR)
   find_package(PROJ NO_MODULE)
 elseif(NOT PROJ_FOUND)
-  if(PROJ_ROOT)
-    set(_CMAKE_FIND_ROOT_PATH ${CMAKE_FIND_ROOT_PATH})
-    set(CMAKE_FIND_ROOT_PATH ${PROJ_ROOT})
-    set(_PROJ_ROOT_OPTS ONLY_CMAKE_FIND_ROOT_PATH)
-  endif()
+  include(CommonFindMacros)
+
+  setup_find_root_context(PROJ)
 
   find_path(PROJ_INCLUDE_DIR "proj_api.h"
-    ${_PROJ_ROOT_OPTS}
+    ${PROJ_FIND_OPTS}
     DOC "Path to the root directory containing the PROJ header file."
     )
 
@@ -37,13 +35,11 @@ elseif(NOT PROJ_FOUND)
 
   find_library(PROJ_LIBRARY proj
     ${_PROJ_LIB_PATH_HINT}
-    ${_PROJ_ROOT_OPTS}
+    ${PROJ_FIND_OPTS}
     DOC "Path to the PROJ library."
     )
 
-  if(PROJ_ROOT)
-    set(CMAKE_FIND_ROOT_PATH ${_CMAKE_FIND_ROOT_PATH})
-  endif()
+  restore_find_root_context(PROJ)
 
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(PROJ DEFAULT_MSG


### PR DESCRIPTION
CMake update affected the way CMAKE_FIND_ROOT_PATH worked in conjuction
with the ONLY_CMAKE_FIND_ROOT_PATH in find_path/find_library functions.
