### PR TITLE
Updated the default dashboard git url to point Kitware's GitHub repo

### DIFF
--- a/cmake/dashboard-scripts/MAPTK_common.cmake
+++ b/cmake/dashboard-scripts/MAPTK_common.cmake
@@ -125,7 +125,7 @@ endif()
 # Selecting Git source to use
 if(NOT DEFINED dashboard_git_url)
   # TODO: When this project goes public, this will probably need to be changed.
-  set(dashboard_git_url "git://kwsource.kitwarein.com/computer-vision/map-tk.git")
+  set(dashboard_git_url "https://github.com/Kitware/maptk.git")
 endif()
 if(NOT DEFINED dashboard_git_branch)
   set(dashboard_git_branch master)


### PR DESCRIPTION
New default now points to the Kitware MapTK git repo on GitHub. Current dashboards are being updated to make sure they are either pointing to this address too, or just removing the override to use the default (which this commit changes).
