### PR TITLE
Return update tracks (inlier labels) from the triangulate tool

### DIFF
--- a/gui/tools/TriangulateTool.cxx
+++ b/gui/tools/TriangulateTool.cxx
@@ -73,7 +73,7 @@ TriangulateTool::~TriangulateTool()
 //-----------------------------------------------------------------------------
 AbstractTool::Outputs TriangulateTool::outputs() const
 {
-  return Landmarks;
+  return Landmarks | Tracks;
 }
 
 //-----------------------------------------------------------------------------
@@ -148,5 +148,6 @@ void TriangulateTool::run()
            << " out of " << init_lms.size() << " tracks.");
 
   this->updateLandmarks(lp);
+  this->updateTracks(tp);
 }
 


### PR DESCRIPTION
The triangulate tool now modifies the tracks by setting the inlier flag.
These changes need to be passed back to the GUI.