### PR TITLE
Fix how we set default Python version to "3".

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ endif()
 option(TELESCULPTOR_ENABLE_MANUALS "Build TeleSculptor user manual(s)" OFF)
 option(TELESCULPTOR_ENABLE_TESTING "Build TeleSculptor testing" OFF)
 option(TELESCULPTOR_ENABLE_TOOLS "Build command line tools" ON)
-set(KWIVER_PYTHON_MAJOR_VERSION "3")
+set(PYTHON_MAJOR_VERSION "3")
 
 if(TELESCULPTOR_SUPERBUILD)
   include(${TELESCULPTOR_CMAKE_DIR}/telesculptor-superbuild.cmake)


### PR DESCRIPTION
Setting KWIVER_PYTHON_MAJOR_VERSION is not effective because this is a CMake
option in KWIVER that is initialized from PYTHON_MAJOR_VERSION, if defined.
So we need to set PYTHON_MAJOR_VERSION to have the desired effect.