### PR TITLE
Update Fletch hash

### DIFF
--- a/CMake/telesculptor-external-fletch.cmake
+++ b/CMake/telesculptor-external-fletch.cmake
@@ -14,7 +14,7 @@ endif()
 ExternalProject_Add(fletch
   PREFIX ${TELESCULPTOR_BINARY_DIR}
   GIT_REPOSITORY "git://github.com/Kitware/fletch.git"
-  GIT_TAG bfb68d2a5dfdc2cd4e06cda1f52dfecfac630004
+  GIT_TAG ea2191a1918b1f381e5cb401b0185ae3d86e54d6
   #GIT_SHALLOW 1
   SOURCE_DIR ${TELESCULPTOR_EXTERNAL_DIR}/fletch
   BINARY_DIR ${TELESCULPTOR_EXTERNAL_DIR}/fletch-build

--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -10,4 +10,6 @@ Fixes since v1.0.0
 
 Build System
 
+ * Updated Fletch to fix broken Qt 5.11 URL.
+
 TeleSculptor Application


### PR DESCRIPTION
This change is to fix the broken Qt 5.11 URL.