### PR TITLE
Ignore landmarks that project very far outside the image.

### DIFF
--- a/doc/release-notes/release.txt
+++ b/doc/release-notes/release.txt
@@ -22,3 +22,7 @@ TeleSculptor Application
  * Fixed a bug in translating the ROI when shifting the geo-origin point.
    Previously the ROI was collapsing because both the min and max point were
    set to the translated min point.
+
+ * Fixed an issues with location precision of landmarks in the Camera View that
+   occured when some points project very far from the image.  These points are
+   now filtered out.

--- a/gui/vtkMaptkCamera.cxx
+++ b/gui/vtkMaptkCamera.cxx
@@ -109,6 +109,17 @@ bool vtkMaptkCamera::ProjectPoint(kwiver::vital::vector_3d const& in,
   }
 
   auto const& ppos = this->MaptkCamera->project(in);
+  // Ignore points that are very far from the image.
+  // Including points that are too far away can degrade the precision
+  // of location of points in the image.
+  int const& w_max = 10 * this->ImageDimensions[0];
+  int const& h_max = 10 * this->ImageDimensions[1];
+  if (ppos[0] < -w_max || ppos[0] > w_max ||
+    ppos[1] < -h_max || ppos[1] > h_max)
+  {
+    return false;
+  }
+
   out[0] = ppos[0];
   out[1] = ppos[1];
   return true;


### PR DESCRIPTION
In some cases landmarks that projected very far from the image caused
a noticable decrease in location precision of all rendered landmarks.
Landmarks appeared to have location rounded off to coarse grid cells.
Not including points that are very far away resolves this rendering issue.