### PR TITLE
Update geo_point to 3d

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -10,6 +10,8 @@ Updates since v1.0.0
 
 TeleSculptor Application
 
+ * Updated the code to work with API changes to kwiver::vital::geo_point.
+
 
 Fixes since v1.0.0
 ------------------

--- a/gui/GroundControlPointsHelper.cxx
+++ b/gui/GroundControlPointsHelper.cxx
@@ -130,12 +130,12 @@ kv::ground_control_point_sptr extractGroundControlPoint(QJsonObject const& f)
     // Set world location and elevation; per the GeoJSON specification
     // (RFC 7946), the coordinates shall have been specified in WGS'84
     constexpr static auto gcs = kv::SRID::lat_lon_WGS84;
-    gcp->set_geo_loc({{coords[0].toDouble(), coords[1].toDouble()}, gcs});
-
+    kv::vector_3d loc(coords[0].toDouble(), coords[1].toDouble(), 0.0);
     if (coords.size() > 2)
     {
-      gcp->set_elevation(coords[2].toDouble());
+      loc[2] = coords[2].toDouble();
     }
+    gcp->set_geo_loc({loc, gcs});
   }
 
   // Get properties
@@ -284,11 +284,8 @@ void GroundControlPointsHelperPrivate::resetPoint(
     auto lgcs = this->mainWindow->localGeoCoordinateSystem();
     if (lgcs.origin().crs() >= 0)
     {
-      auto const& loc = gcp->loc();
-      gcp->set_geo_loc({
-        lgcs.origin().location() + kv::vector_2d{loc[0], loc[1]},
-        lgcs.origin().crs()});
-      gcp->set_elevation(lgcs.origin_altitude() + loc[2]);
+      kwiver::vital::vector_3d loc(lgcs.origin().location() + gcp->loc());
+      gcp->set_geo_loc({loc, lgcs.origin().crs()});
     }
 
     if (!(options & Reset::Silent))

--- a/gui/GroundControlPointsView.cxx
+++ b/gui/GroundControlPointsView.cxx
@@ -174,7 +174,7 @@ void GroundControlPointsViewPrivate::showPoint(id_t id)
       this->currentPoint = id;
 
       auto const& gl = gcp->geo_loc();
-      auto const grl = [&gl]() -> kv::vector_2d {
+      auto const grl = [&gl]() -> kv::vector_3d {
         if (!gl.is_empty())
         {
           try
@@ -186,7 +186,7 @@ void GroundControlPointsViewPrivate::showPoint(id_t id)
             qWarning() << "Geo-conversion from GCS" << gl.crs() << "failed";
           }
         }
-        return { 0.0, 0.0 };
+        return { 0.0, 0.0, 0.0 };
       }();
 
       with_expr (qtScopedBlockSignals{this->UI.easting})
@@ -252,7 +252,7 @@ void GroundControlPointsViewPrivate::copyLocation(
     auto const& gl = gcp->geo_loc();
     if (!gl.is_empty())
     {
-      auto const grl = [&gl]() -> kv::vector_2d {
+      auto const grl = [&gl]() -> kv::vector_3d {
         try
         {
           return gl.location(kv::SRID::lat_lon_WGS84);
@@ -261,7 +261,7 @@ void GroundControlPointsViewPrivate::copyLocation(
         {
           qWarning() << "Geo-conversion from GCS" << gl.crs() << "failed";
         }
-        return { 0.0, 0.0 };
+        return { 0.0, 0.0, 0.0 };
       }();
 
       QStringList values;

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -434,10 +434,8 @@ void MainWindowPrivate::shiftGeoOrigin(kv::vector_3d const& offset)
   {
     return;
   }
-  lgcs.set_origin_altitude(lgcs.origin_altitude() + offset[2]);
-  lgcs.set_origin(kv::geo_point(lgcs.origin().location()
-                                  + kv::vector_2d(offset[0], offset[1]),
-                                lgcs.origin().crs()));
+  kwiver::vital::vector_3d new_origin = lgcs.origin().location() + offset;
+  lgcs.set_origin(kv::geo_point(new_origin, lgcs.origin().crs()));
   sfmConstraints->set_local_geo_cs(lgcs);
 
   if (!sfmConstraints->get_local_geo_cs().origin().is_empty() &&

--- a/maptk/geo_reference_points_io.cxx
+++ b/maptk/geo_reference_points_io.cxx
@@ -107,7 +107,7 @@ void load_reference_file(vital::path_t const& reference_file,
       LOG_DEBUG(logger, "lgcs origin zone: " << zone.number );
       lgcs.set_origin( vital::geo_point( gp.location( crs ), crs ) );
     }
-    vital::vector_2d utm = gp.location(crs);
+    vital::vector_3d utm = gp.location(crs);
 
     vec[0] = utm.x();
     vec[1] = utm.y();
@@ -137,8 +137,7 @@ void load_reference_file(vital::path_t const& reference_file,
   {
     // Initialize lgcs center
     mean /= static_cast<double>(reference_lms.size());
-    lgcs.set_origin( vital::geo_point( vital::vector_2d( mean.x(), mean.y() ), crs ) );
-    lgcs.set_origin_altitude( mean.z() );
+    lgcs.set_origin( vital::geo_point( mean, crs ) );
     LOG_DEBUG(logger, "mean position (lgcs origin): " << mean.transpose());
   }
 
@@ -147,11 +146,7 @@ void load_reference_file(vital::path_t const& reference_file,
   LOG_INFO(logger, "transforming ground control points to local coordinates");
   for(vital::landmark_map::map_landmark_t::value_type & p : reference_lms)
   {
-    auto loc = p.second->loc();
-    auto origin_pt = lgcs.origin().location();
-    loc[0] -= origin_pt[0];
-    loc[1] -= origin_pt[1];
-    loc[2] -= lgcs.origin_altitude();
+    auto loc = p.second->loc() - lgcs.origin().location();
     dynamic_cast<vital::landmark_d*>(p.second.get())->set_loc(loc);
   }
 

--- a/maptk/write_pdal.cxx
+++ b/maptk/write_pdal.cxx
@@ -108,8 +108,7 @@ write_pdal(vital::path_t const& filename,
   }
 
   int crs = lgcs.origin().crs();
-  kv::vector_2d offset_xy(0.0, 0.0);
-  double offset_z = 0.0;
+  kv::vector_3d offset(0.0, 0.0, 0.0);
   pdal::PointViewPtr view;
   // handle special cases of non-geographic coordinates
   if( crs < 0 )
@@ -121,8 +120,7 @@ write_pdal(vital::path_t const& filename,
   }
   else
   {
-    offset_xy = lgcs.origin().location();
-    offset_z = lgcs.origin_altitude();
+    offset = lgcs.origin().location();
     std::string srs_name = "EPSG:" + std::to_string(crs);
     pdal::SpatialReference srs;
     srs = pdal::SpatialReference(srs_name);
@@ -131,10 +129,7 @@ write_pdal(vital::path_t const& filename,
 
   for( unsigned int id=0; id < points.size(); ++id )
   {
-    kv::vector_3d pt = points[id];
-    pt[0] += offset_xy[0];
-    pt[1] += offset_xy[1];
-    pt[2] += offset_z;
+    kv::vector_3d pt = points[id] + offset;
     view->setField(pdal::Dimension::Id::X, id, pt.x());
     view->setField(pdal::Dimension::Id::Y, id, pt.y());
     view->setField(pdal::Dimension::Id::Z, id, pt.z());


### PR DESCRIPTION
The KWIVER geo_point has been updated to use a 3D location instead of 2D and to remove the separate elevation field.  This change makes TeleSculptor work with API changes.