### PR TITLE
Speed up playback

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -123,6 +123,8 @@ TeleSculptor Application
    depth maps which is currently unused and all zeros.  Likewise with Weights
    of depth maps when no mask is used.
 
+ * Improved video playback speed by avoiding excessive seeking.
+
 Packaging
 
  * The packaging for Linux has been corrected so that setting LD_LIBRARY_PATH

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1144,10 +1144,18 @@ void MainWindowPrivate::loadEmptyImage(vtkMaptkCamera* camera)
 //-----------------------------------------------------------------------------
 void MainWindowPrivate::loadImage(FrameData frame)
 {
-  // TODO: check if seek vs next_frame is needed
   if (frame.id != this->currentVideoTimestamp.get_frame())
   {
-    if (!this->videoSource ||
+    // step through next frames if the requested frame is just a few ahead
+    if (this->videoSource &&
+        this->currentVideoTimestamp.get_frame() < frame.id &&
+        this->currentVideoTimestamp.get_frame() + 10 > frame.id)
+    {
+      while (this->videoSource->next_frame(this->currentVideoTimestamp) &&
+             this->currentVideoTimestamp.get_frame() < frame.id);
+    }
+    // otherwise seek to the requested frame
+    else if (!this->videoSource ||
         !videoSource->seek_frame(this->currentVideoTimestamp, frame.id))
     {
       this->loadEmptyImage(frame.camera);


### PR DESCRIPTION
Playing back video in TeleSculptor was slower than necessary because advancing the video is always done by sending a message to go to a specific frame number. Previously this meant that seek was called for each frame change, even if the frame number was just stepping to the next frame.  Seek calls step the video back to the previous key frame and then forward again to reach the target frame.  It is more efficient to first check if the video is already just a few frames behind the target and then advance the video in that case instead of seeking.