### PR TITLE
Update Metadata fields using current metadata

### DIFF
--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1201,15 +1201,7 @@ void MainWindowPrivate::loadImage(FrameData frame)
       this->UI.worldView->setImageData(imageData, size);
 
       // Update metadata view
-      if (!this->videoMetadataMap)
-      {
-        this->UI.metadata->updateMetadata(kv::metadata_vector{});
-      }
-      else
-      {
-        auto const& mdv = this->videoMetadataMap->get_vector(frame.id);
-        this->UI.metadata->updateMetadata(mdv);
-      }
+      this->UI.metadata->updateMetadata(videoSource->frame_metadata());
     }
   }
   else

--- a/gui/MetadataView.cxx
+++ b/gui/MetadataView.cxx
@@ -281,7 +281,10 @@ void MetadataView::updateMetadata(kv::metadata_vector const& mdVec)
 {
   QTE_D();
 
-  for (auto const k : d->itemIds())
+  auto traits = kv::metadata_traits{};
+
+  auto const keys = d->itemIds();
+  for (auto const k : keys)
   {
     d->clearItemValue(k);
   }
@@ -296,6 +299,11 @@ void MetadataView::updateMetadata(kv::metadata_vector const& mdVec)
 
       if (mdi)
       {
+        if (!keys.contains(k))
+        {
+          auto const tag = static_cast<kv::vital_metadata_tag>(k);
+          d->addItem(k, qtString(traits.tag_to_name(tag)));
+        }
         d->setItemValue(k, qtString(mdi->as_string()));
       }
     }


### PR DESCRIPTION
This branch is the start of change that moves away from pre-scanning the
entire video into a metadata map.  For the MetadataView it is a relatively
simple change to always update to the current frame metadata.  The main
difference is that the full set of metadata keys is not known in advance.
The set of keys must expand as each new frame is visited if a new key
is encountered.