### PR TITLE
Make metadata scan optional

### DIFF
--- a/doc/release-notes/master.txt
+++ b/doc/release-notes/master.txt
@@ -2,7 +2,7 @@ TeleSculptor v1.1.0 Release Notes
 =================================
 
 This is a minor release of TeleSculptor that provides both new functionality
-and fixes over the previous v1.0.0 release. 
+and fixes over the previous v1.0.0 release.
 
 
 Updates since v1.0.0
@@ -104,6 +104,10 @@ TeleSculptor Application
  * Added a special "Run End-to-End" tool to the compute menu that runs a
    pipeline of all main tools in order to start from a video and end with
    a fused 3D surface mesh without any user interaction.
+
+ * Improved video loading to not require an entire scan of the video upon each
+   open.  The scan is still needed to collect metadata, but this can now be
+   canceled if metadata is not required.
 
 
 Fixes since v1.0.0

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -2880,6 +2880,8 @@ void MainWindow::acceptToolResults(
         d->shiftGeoOrigin(offset);
       }
     }
+    // Set the frame sampling rate for coloring based on number of cameras
+    d->UI.worldView->initFrameSampling(static_cast<int>(data->cameras->size()));
   }
   else if (updateNeeded)
   {

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -680,7 +680,11 @@ void MainWindowPrivate::addFrame(
 void MainWindowPrivate::updateFrames(
   std::shared_ptr<kv::metadata_map::map_metadata_t> mdMap)
 {
-  this->videoMetadataMap = std::make_shared<kv::simple_metadata_map>(*mdMap);
+  if (mdMap)
+  {
+    this->videoMetadataMap = std::make_shared<kv::simple_metadata_map>(*mdMap);
+    this->UI.metadata->updateMetadata(mdMap);
+  }
 
   bool ignore_metadata =
     this->freestandingConfig->get_value<bool>(
@@ -690,8 +694,6 @@ void MainWindowPrivate::updateFrames(
   {
     sfmConstraints->set_metadata(videoMetadataMap);
   }
-
-  this->UI.metadata->updateMetadata(mdMap);
 
   if (this->cameraMap()->size() == 0)
   {

--- a/gui/VideoImport.cxx
+++ b/gui/VideoImport.cxx
@@ -106,6 +106,8 @@ void VideoImport::run()
 {
   QTE_D();
 
+  d->canceled = false;
+
   if (!video_input::check_nested_algo_configuration(
     BLOCK_VR, d->config))
   {
@@ -132,7 +134,7 @@ void VideoImport::run()
     return;
   }
 
-  auto num_frames = d->video_reader->num_frames();
+  auto num_frames = static_cast<int>(d->video_reader->num_frames());
 
   QString description = QString("&Loading video from %1 (Frame %2)")
     .arg(QFileInfo{qtString(d->videoPath)}.fileName());
@@ -148,6 +150,12 @@ void VideoImport::run()
 
     QString desc = description.arg(frame);
     emit this->progressChanged(desc, frame * 100 / num_frames);
+  }
+
+  if (d->canceled)
+  {
+    // invalidate the metadata map
+    metadataMap = nullptr;
   }
 
   emit this->progressChanged(QString("Loading video complete"), 100);

--- a/gui/VideoImport.cxx
+++ b/gui/VideoImport.cxx
@@ -136,7 +136,8 @@ void VideoImport::run()
 
   auto num_frames = static_cast<int>(d->video_reader->num_frames());
 
-  QString description = QString("&Loading video from %1 (Frame %2)")
+  QString description = QString("&Scanning metadata in %1 (Frame %2). "
+                                "Cancel to ignore metadata.")
     .arg(QFileInfo{qtString(d->videoPath)}.fileName());
   while (d->video_reader->next_frame(currentTimestamp) && !d->canceled)
   {

--- a/gui/tools/TrackFeaturesTool.cxx
+++ b/gui/tools/TrackFeaturesTool.cxx
@@ -287,16 +287,21 @@ void TrackFeaturesTool::run()
     d->mask_reader->open(this->data()->maskPath);
   }
 
-  if (!md_map)
-  {
-    md_map = d->video_reader->metadata_map();
-  }
-
   std::vector<kwiver::vital::frame_id_t> valid_frames;
-  if (md_map)
+  if (md_map && md_map->size() > 0)
   {
     auto fs = md_map->frames();
     valid_frames = std::vector<kwiver::vital::frame_id_t>(fs.begin(), fs.end());
+  }
+  else
+  {
+    auto const num_frames = static_cast<kwiver::vital::frame_id_t>(
+                              d->video_reader->num_frames());
+    valid_frames.reserve(num_frames);
+    for (kwiver::vital::frame_id_t f = 1; f <= num_frames; ++f)
+    {
+      valid_frames.push_back(f);
+    }
   }
 
   std::vector<kwiver::vital::frame_id_t> camera_frames;


### PR DESCRIPTION
This is the last feature change I would like to make before releasing TeleSculptor v1.1.0.  This is a big improvement to usability.  Previously we required a scan of the video to count frames and load metadata each time it was opened.  This could take a full minute, or in some cases much longer.  With a recent KWIVER change we can now get an accurate frame count in constant time.  So we can now immediately load everything except the metadata map in a few seconds.

The `VideoImporter` still does a scan to build the metadata map, but this is now cancel-able.  The algorithms can still run without the metadata if you cancel, or you can wait and run with metadata.