### PR TITLE
Moved find_package calls all into telesculptor-depends.cmake

### DIFF
--- a/CMake/telesculptor-depends.cmake
+++ b/CMake/telesculptor-depends.cmake
@@ -1,5 +1,5 @@
 ###
-# use kwiver/fletch/telesculptor util methods
+# Find all package dependencies
 #
 
 message(STATUS "Looking for kwiver in : ${kwiver_DIR}")
@@ -17,3 +17,54 @@ include( kwiver-flags )
 include( kwiver-configcheck )
 include( telesculptor-utils ) # local utilities
 
+# We must find third party packages used by both KWIVER and TeleSculptor here
+# otherwise CMake will be unable to find those targets.
+# In the future, this should be exported by KWIVER.
+
+set(Qt5_MODULES Core Designer UiPlugin Widgets Svg Xml)
+find_package(Qt5 5.7 COMPONENTS ${Qt5_MODULES} REQUIRED)
+
+set(QT_LIBRARIES )
+foreach(module ${Qt5_MODULES})
+  list(APPEND QT_LIBRARIES Qt5::${module})
+endforeach()
+
+find_package(qtExtensions REQUIRED)
+include(${qtExtensions_USE_FILE})
+if(QTE_QT_VERSION VERSION_EQUAL "4")
+  message(FATAL_ERROR "${PROJECT_NAME} does not support Qt4. "
+    "But QTE_QT_VERSION is ${QTE_QT_VERSION}. "
+    "Please provide path to qtExtensions built with Qt version 5 or higher.")
+endif()
+
+find_package(VTK REQUIRED
+  COMPONENTS
+  vtkFiltersSources
+  vtkGUISupportQt
+  vtkIOGeometry
+  vtkIOImage
+  vtkIOPLY
+  vtkIOXML
+  vtkImagingCore
+  vtkInteractionStyle
+  vtkInteractionWidgets
+  vtkRenderingAnnotation
+  vtkRenderingFreeType
+  )
+
+if(VTK_VERSION VERSION_LESS 8.2)
+  message(FATAL_ERROR "${PROJECT_NAME} supports VTK >= v8.2 "
+    "(Found ${VTK_VERSION})")
+endif()
+include(${VTK_USE_FILE})
+if(VTK_QT_VERSION VERSION_EQUAL "4")
+  message(FATAL_ERROR "${PROJECT_NAME} does not support Qt4. "
+    "But VTK_QT_VERSION is ${VTK_QT_VERSION}. "
+    "Please provide path to VTK built with Qt version 5 or higher.")
+endif()
+if(VTK_RENDERING_BACKEND STREQUAL "OpenGL")
+  message(FATAL_ERROR "${PROJECT_NAME} does not support VTK's OpenGL backend.\n"
+    "The old OpenGL backend is known to have rendering issues and "
+    "has been deprecated in newer versions of VTK.\n"
+    "Please provide path to VTK built with VTK_RENDERING_BACKEND = OpenGL2.")
+endif()

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,49 +1,4 @@
 set(CMAKE_AUTOMOC ON)
-set(Qt5_MODULES Core Designer UiPlugin Widgets Svg Xml)
-find_package(Qt5 5.7 COMPONENTS ${Qt5_MODULES} REQUIRED)
-set(QT_LIBRARIES )
-foreach(module ${Qt5_MODULES})
-  list(APPEND QT_LIBRARIES Qt5::${module})
-endforeach()
-
-find_package(qtExtensions REQUIRED)
-include(${qtExtensions_USE_FILE})
-if(QTE_QT_VERSION VERSION_EQUAL "4")
-  message(FATAL_ERROR "${PROJECT_NAME} does not support Qt4. "
-    "But QTE_QT_VERSION is ${QTE_QT_VERSION}. "
-    "Please provide path to qtExtensions built with Qt version 5 or higher.")
-endif()
-
-find_package(VTK REQUIRED
-  COMPONENTS
-  vtkFiltersSources
-  vtkGUISupportQt
-  vtkIOGeometry
-  vtkIOImage
-  vtkIOPLY
-  vtkIOXML
-  vtkImagingCore
-  vtkInteractionStyle
-  vtkInteractionWidgets
-  vtkRenderingAnnotation
-  vtkRenderingFreeType
-  )
-if(VTK_VERSION VERSION_LESS 8.2)
-  message(FATAL_ERROR "${PROJECT_NAME} supports VTK >= v8.2 "
-    "(Found ${VTK_VERSION})")
-endif()
-include(${VTK_USE_FILE})
-if(VTK_QT_VERSION VERSION_EQUAL "4")
-  message(FATAL_ERROR "${PROJECT_NAME} does not support Qt4. "
-    "But VTK_QT_VERSION is ${VTK_QT_VERSION}. "
-    "Please provide path to VTK built with Qt version 5 or higher.")
-endif()
-if(VTK_RENDERING_BACKEND STREQUAL "OpenGL")
-  message(FATAL_ERROR "${PROJECT_NAME} does not support VTK's OpenGL backend.\n"
-    "The old OpenGL backend is known to have rendering issues and "
-    "has been deprecated in newer versions of VTK.\n"
-    "Please provide path to VTK built with VTK_RENDERING_BACKEND = OpenGL2.")
-endif()
 
 #
 # This option should be set if you want to do a bundle fixup for
@@ -209,10 +164,10 @@ target_link_libraries(TeleSculptor
   kwiver::kwiver_adapter
   kwiver::kwiver_algo_core
   kwiver::kwiver_algo_mvg
-  kwiver_algo_qt_widgets
+  kwiver::kwiver_algo_qt_widgets
   kwiver::sprokit_pipeline
   kwiver::vital_vpm
-  kwiver_algo_vtk
+  kwiver::kwiver_algo_vtk
   qtExtensions
   ${AppKit}
   ${VTK_LIBRARIES}


### PR DESCRIPTION
This is needed to put all the targets in the same scope. If KWIVER
and VTK are found in different scopes then linking to a KWIVER library
that uses VTK will not be able to find dependent VTK targets.