### PR TITLE
Remove includes of vtkGeometryFilter.h

### DIFF
--- a/gui/DepthMapView.cxx
+++ b/gui/DepthMapView.cxx
@@ -38,7 +38,6 @@
 
 #include <vtkCamera.h>
 #include <vtkGenericOpenGLRenderWindow.h>
-#include <vtkGeometryFilter.h>
 #include <vtkImageData.h>
 #include <vtkInteractorStyleRubberBand2D.h>
 #include <vtkMaptkImageDataGeometryFilter.h>

--- a/gui/WorldView.cxx
+++ b/gui/WorldView.cxx
@@ -66,7 +66,6 @@
 #include <vtkEventQtSlotConnect.h>
 #include <vtkFlyingEdges3D.h>
 #include <vtkGenericOpenGLRenderWindow.h>
-#include <vtkGeometryFilter.h>
 #include <vtkImageActor.h>
 #include <vtkImageData.h>
 #include <vtkMaptkImageDataGeometryFilter.h>


### PR DESCRIPTION
Remove directives to include `vtkGeometryFilter.h`; this header does not seem to be necessary (we never use the class directly), and indeed, even in VTK it's not obvious that the class is ever used. More importantly, trying to include the header causes problems with VTK 9.