### PR TITLE
Fix inappropriate use of literal 0

### DIFF
--- a/gui/AboutDialog.h
+++ b/gui/AboutDialog.h
@@ -42,7 +42,7 @@ class AboutDialog : public QDialog
   Q_OBJECT
 
 public:
-  explicit AboutDialog(QWidget* parent = 0, Qt::WindowFlags f = 0);
+  explicit AboutDialog(QWidget* parent = nullptr, Qt::WindowFlags f = {});
   ~AboutDialog() override;
 
 protected slots:

--- a/gui/ActorColorButton.h
+++ b/gui/ActorColorButton.h
@@ -44,7 +44,7 @@ class ActorColorButton : public qtColorButton
   Q_OBJECT
 
 public:
-  explicit ActorColorButton(QWidget* parent = 0);
+  explicit ActorColorButton(QWidget* parent = nullptr);
   ~ActorColorButton() override;
 
   void addActor(vtkActor*);

--- a/gui/CameraOptions.h
+++ b/gui/CameraOptions.h
@@ -45,7 +45,8 @@ class CameraOptions : public QWidget
 
 public:
   explicit CameraOptions(vtkMaptkCameraRepresentation*,
-                         QWidget* parent = 0, Qt::WindowFlags flags = 0);
+                         QWidget* parent = nullptr,
+                         Qt::WindowFlags flags = {});
   ~CameraOptions() override;
 
 signals:

--- a/gui/CameraView.cxx
+++ b/gui/CameraView.cxx
@@ -565,7 +565,7 @@ CameraView::CameraView(QWidget* parent, Qt::WindowFlags flags)
   d->emptyImage->AllocateScalars(VTK_UNSIGNED_CHAR, 1);
   d->emptyImage->SetScalarComponentFromDouble(0, 0, 0, 0, 0.0);
 
-  this->setImageData(0, QSize(1, 1));
+  this->setImageData(nullptr, QSize{1, 1});
 }
 
 //-----------------------------------------------------------------------------

--- a/gui/CameraView.h
+++ b/gui/CameraView.h
@@ -52,7 +52,7 @@ class CameraView : public QWidget
   Q_OBJECT
 
 public:
-  explicit CameraView(QWidget* parent = 0, Qt::WindowFlags flags = 0);
+  explicit CameraView(QWidget* parent = nullptr, Qt::WindowFlags flags = {});
   ~CameraView() override;
 
   void addFeatureTrack(kwiver::vital::track const&);

--- a/gui/ColorizeSurfaceOptions.h
+++ b/gui/ColorizeSurfaceOptions.h
@@ -48,8 +48,9 @@ class ColorizeSurfaceOptions : public QWidget
   Q_OBJECT
 
 public:
-  explicit ColorizeSurfaceOptions(const QString &settingsGroup,
-      QWidget* parent = 0, Qt::WindowFlags flags = 0);
+  explicit ColorizeSurfaceOptions(QString const& settingsGroup,
+                                  QWidget* parent = nullptr,
+                                  Qt::WindowFlags flags = {});
   ~ColorizeSurfaceOptions() override;
 
   void addColorDisplay(std::string name);

--- a/gui/DataColorOptions.h
+++ b/gui/DataColorOptions.h
@@ -46,8 +46,9 @@ class DataColorOptions : public QWidget
   Q_OBJECT
 
 public:
-  explicit DataColorOptions(QString const& settingsGroup, QWidget* parent = 0,
-                            Qt::WindowFlags flags = 0);
+  explicit DataColorOptions(QString const& settingsGroup,
+                            QWidget* parent = nullptr,
+                            Qt::WindowFlags flags = {});
   ~DataColorOptions() override;
 
   QIcon icon() const;

--- a/gui/DataFilterOptions.h
+++ b/gui/DataFilterOptions.h
@@ -49,8 +49,9 @@ public:
   };
   Q_DECLARE_FLAGS(ActiveFilters, ActiveFilter)
 
-  explicit DataFilterOptions(QString const& settingsGroup, QWidget* parent = 0,
-                             Qt::WindowFlags flags = 0);
+  explicit DataFilterOptions(QString const& settingsGroup,
+                             QWidget* parent = nullptr,
+                             Qt::WindowFlags flags = {});
   ~DataFilterOptions() override;
 
   double minimum() const;

--- a/gui/DepthMapFilterOptions.h
+++ b/gui/DepthMapFilterOptions.h
@@ -42,9 +42,9 @@ class DepthMapFilterOptions : public QWidget
   Q_OBJECT
 
 public:
-  explicit DepthMapFilterOptions(const QString& settingsGroup,
-                                 QWidget* parent = 0,
-                                 Qt::WindowFlags flags = 0);
+  explicit DepthMapFilterOptions(QString const& settingsGroup,
+                                 QWidget* parent = nullptr,
+                                 Qt::WindowFlags flags = {});
   ~DepthMapFilterOptions() override;
 
   double weightMinimum() const;

--- a/gui/DepthMapOptions.h
+++ b/gui/DepthMapOptions.h
@@ -51,8 +51,9 @@ public:
   };
 
 public:
-  explicit DepthMapOptions(const QString& settingsGroup,
-                           QWidget* parent = 0, Qt::WindowFlags flags = 0);
+  explicit DepthMapOptions(QString const& settingsGroup,
+                           QWidget* parent = nullptr,
+                           Qt::WindowFlags flags = {});
   ~DepthMapOptions() override;
 
   DisplayMode displayMode() const;

--- a/gui/DepthMapView.cxx
+++ b/gui/DepthMapView.cxx
@@ -273,7 +273,7 @@ void DepthMapView::setDepthGeometryFilter(
   {
     d->inputDepthGeometryFilter = geometryFilter;
     d->scalarFilter->SetInputConnection(d->inputDepthGeometryFilter ?
-      d->inputDepthGeometryFilter->GetOutputPort() : 0);
+      d->inputDepthGeometryFilter->GetOutputPort() : nullptr);
   }
 }
 

--- a/gui/DepthMapView.h
+++ b/gui/DepthMapView.h
@@ -43,7 +43,7 @@ class DepthMapView : public QWidget
   Q_OBJECT
 
 public:
-  explicit DepthMapView(QWidget* parent = 0, Qt::WindowFlags flags = 0);
+  explicit DepthMapView(QWidget* parent = nullptr, Qt::WindowFlags flags = {});
   ~DepthMapView() override;
 
   void enableAntiAliasing(bool enable);

--- a/gui/DepthMapViewOptions.cxx
+++ b/gui/DepthMapViewOptions.cxx
@@ -61,8 +61,6 @@ public:
   };
 
 public:
-  DepthMapViewOptionsPrivate() : actor(0), rangeInitialized(false) {}
-
   void setPopup(QToolButton* button, QWidget* widget);
 
   void addMode(QAbstractButton* button, char const* arrayName,
@@ -77,9 +75,9 @@ public:
   QButtonGroup* modeButtons;
   QList<ModeInformation> modes;
 
-  vtkActor* actor;
+  vtkActor* actor = nullptr;
 
-  bool rangeInitialized;
+  bool rangeInitialized = false;
 };
 
 //-----------------------------------------------------------------------------
@@ -135,7 +133,7 @@ DepthMapViewOptions::DepthMapViewOptions(
           this, &DepthMapViewOptions::setUncertaintyIcon);
 
   d->modeButtons = new QButtonGroup(this);
-  d->addMode(d->UI.color, DepthMapArrays::TrueColor, 0);
+  d->addMode(d->UI.color, DepthMapArrays::TrueColor, nullptr);
   d->addMode(d->UI.depth, DepthMapArrays::Depth,
              d->depthOptions);
   d->addMode(d->UI.weight, DepthMapArrays::Weight,

--- a/gui/DepthMapViewOptions.h
+++ b/gui/DepthMapViewOptions.h
@@ -47,8 +47,9 @@ class DepthMapViewOptions : public QWidget
   Q_OBJECT
 
 public:
-  explicit DepthMapViewOptions(const QString& settingsGroup,
-                               QWidget* parent = 0, Qt::WindowFlags flags = 0);
+  explicit DepthMapViewOptions(QString const& settingsGroup,
+                               QWidget* parent = nullptr,
+                               Qt::WindowFlags flags = {});
   ~DepthMapViewOptions() override;
 
   void setActor(vtkActor*);

--- a/gui/FeatureOptions.h
+++ b/gui/FeatureOptions.h
@@ -42,9 +42,9 @@ class FeatureOptions : public PointOptions
   Q_OBJECT
 
 public:
-  explicit FeatureOptions(vtkMaptkFeatureTrackRepresentation*,
-                          QString const& settingsGroup,
-                          QWidget* parent = 0, Qt::WindowFlags flags = 0);
+  explicit FeatureOptions(
+    vtkMaptkFeatureTrackRepresentation*, QString const& settingsGroup,
+    QWidget* parent = nullptr, Qt::WindowFlags flags = {});
   ~FeatureOptions() override;
 
 public slots:

--- a/gui/GradientSelector.h
+++ b/gui/GradientSelector.h
@@ -70,7 +70,7 @@ public:
     Rainbow
   };
 
-  explicit GradientSelector(QWidget* parent = 0);
+  explicit GradientSelector(QWidget* parent = nullptr);
   ~GradientSelector() override;
 
   qtGradient currentGradient() const;

--- a/gui/GroundControlPointsView.h
+++ b/gui/GroundControlPointsView.h
@@ -45,7 +45,7 @@ class GroundControlPointsView : public QWidget
 
 public:
   explicit GroundControlPointsView(
-    QWidget* parent = 0, Qt::WindowFlags flags = 0);
+    QWidget* parent = nullptr, Qt::WindowFlags flags = {});
   ~GroundControlPointsView();
 
   void setHelper(GroundControlPointsHelper*);

--- a/gui/GroundControlPointsWidget.h
+++ b/gui/GroundControlPointsWidget.h
@@ -58,7 +58,7 @@ class GroundControlPointsWidget : public QObject
   Q_OBJECT
 
 public:
-  GroundControlPointsWidget(QObject* parent = 0);
+  GroundControlPointsWidget(QObject* parent = nullptr);
   ~GroundControlPointsWidget();
 
   void setInteractor(vtkRenderWindowInteractor* iren);

--- a/gui/ImageOptions.h
+++ b/gui/ImageOptions.h
@@ -45,7 +45,8 @@ class ImageOptions : public QWidget
 
 public:
   explicit ImageOptions(QString const& settingsGroup,
-                        QWidget* parent = 0, Qt::WindowFlags flags = 0);
+                        QWidget* parent = nullptr,
+                        Qt::WindowFlags flags = {});
   ~ImageOptions() override;
 
   void addActor(vtkImageActor*);

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1010,7 +1010,7 @@ void MainWindowPrivate::updateCameraView()
 {
   if (this->activeCameraIndex < 1)
   {
-    this->loadEmptyImage(0);
+    this->loadEmptyImage(nullptr);
     this->UI.cameraView->setActiveFrame(static_cast<unsigned>(-1));
     this->UI.cameraView->clearLandmarks();
     this->UI.cameraView->clearGroundControlPoints();
@@ -1025,7 +1025,7 @@ void MainWindowPrivate::updateCameraView()
 
   if (!activeFrame)
   {
-    this->loadEmptyImage(0);
+    this->loadEmptyImage(nullptr);
     this->UI.cameraView->clearLandmarks();
     return;
   }
@@ -1159,8 +1159,8 @@ void MainWindowPrivate::loadEmptyImage(kwiver::arrows::vtk::vtkKwiverCamera* cam
     imageDimensions = QSize(w, h);
   }
 
-  this->UI.cameraView->setImageData(0, imageDimensions);
-  this->UI.worldView->setImageData(0, imageDimensions);
+  this->UI.cameraView->setImageData(nullptr, imageDimensions);
+  this->UI.worldView->setImageData(nullptr, imageDimensions);
 }
 
 //-----------------------------------------------------------------------------
@@ -2806,7 +2806,7 @@ void MainWindow::executeTool(QObject* object)
 
     if (!tool->execute())
     {
-      d->setActiveTool(0);
+      d->setActiveTool(nullptr);
     }
     else
     {
@@ -2843,7 +2843,7 @@ void MainWindow::acceptToolFinalResults()
                       d->activeTool->description(),
                       100);
   }
-  d->setActiveTool(0);
+  d->setActiveTool(nullptr);
 }
 
 //-----------------------------------------------------------------------------
@@ -2894,13 +2894,13 @@ void MainWindow::acceptToolResults(
 
     auto const outputs = d->activeTool->outputs();
 
-    d->toolUpdateCameras = NULL;
-    d->toolUpdateLandmarks = NULL;
-    d->toolUpdateTracks = NULL;
-    d->toolUpdateTrackChanges = NULL;
+    d->toolUpdateCameras = nullptr;
+    d->toolUpdateLandmarks = nullptr;
+    d->toolUpdateTracks = nullptr;
+    d->toolUpdateTrackChanges = nullptr;
     d->toolUpdateActiveFrame = -1;
-    d->toolUpdateDepth = NULL;
-    d->toolUpdateVolume = NULL;
+    d->toolUpdateDepth = nullptr;
+    d->toolUpdateVolume = nullptr;
     if (outputs.testFlag(AbstractTool::Cameras))
     {
       d->toolUpdateCameras = data->cameras;

--- a/gui/MainWindow.h
+++ b/gui/MainWindow.h
@@ -56,7 +56,7 @@ class MainWindow : public QMainWindow
   Q_OBJECT
 
 public:
-  explicit MainWindow(QWidget* parent = 0, Qt::WindowFlags flags = 0);
+  explicit MainWindow(QWidget* parent = nullptr, Qt::WindowFlags flags = {});
   ~MainWindow() override;
 
   kwiver::arrows::vtk::vtkKwiverCamera* activeCamera();

--- a/gui/MatchMatrixWindow.h
+++ b/gui/MatchMatrixWindow.h
@@ -46,7 +46,8 @@ class MatchMatrixWindow : public QMainWindow
   Q_OBJECT
 
 public:
-  explicit MatchMatrixWindow(QWidget* parent = 0, Qt::WindowFlags flags = 0);
+  explicit MatchMatrixWindow(QWidget* parent = nullptr,
+                             Qt::WindowFlags flags = {});
   ~MatchMatrixWindow() override;
 
 public slots:

--- a/gui/PointOptions.h
+++ b/gui/PointOptions.h
@@ -48,7 +48,8 @@ class PointOptions : public QWidget
 
 public:
   explicit PointOptions(QString const& settingsGroup,
-                        QWidget* parent = 0, Qt::WindowFlags flags = 0);
+                        QWidget* parent = nullptr,
+                        Qt::WindowFlags flags = {});
   ~PointOptions() override;
 
   void addActor(vtkActor*);

--- a/gui/RulerOptions.h
+++ b/gui/RulerOptions.h
@@ -44,8 +44,8 @@ class RulerOptions : public QWidget
 
 public:
   explicit RulerOptions(QString const& settingsGroup,
-                        QWidget* parent = 0,
-                        Qt::WindowFlags flags = 0);
+                        QWidget* parent = nullptr,
+                        Qt::WindowFlags flags = {});
   ~RulerOptions() override;
 
   void setRulerHelper(RulerHelper* helper);

--- a/gui/RulerWidget.h
+++ b/gui/RulerWidget.h
@@ -58,7 +58,7 @@ class RulerWidget : public QObject
   Q_OBJECT
 
 public:
-  RulerWidget(QObject* parent = 0);
+  RulerWidget(QObject* parent = nullptr);
   ~RulerWidget();
 
   void setInteractor(vtkRenderWindowInteractor* iren);

--- a/gui/VolumeOptions.h
+++ b/gui/VolumeOptions.h
@@ -50,7 +50,8 @@ class VolumeOptions : public QWidget
 
 public:
   explicit VolumeOptions(QString const& settingsGroup,
-      QWidget* parent = 0, Qt::WindowFlags flags = 0);
+                         QWidget* parent = nullptr,
+                         Qt::WindowFlags flags = {});
   ~VolumeOptions() override;
 
   void setActor(vtkActor* actor);

--- a/gui/WorldView.cxx
+++ b/gui/WorldView.cxx
@@ -587,7 +587,7 @@ WorldView::WorldView(QWidget* parent, Qt::WindowFlags flags)
   d->emptyImage->AllocateScalars(VTK_UNSIGNED_CHAR, 1);
   d->emptyImage->SetScalarComponentFromDouble(0, 0, 0, 0, 0.0);
 
-  this->setImageData(0, QSize(1, 1));
+  this->setImageData(nullptr, QSize{1, 1});
 
   // Set up landmark actor
   vtkNew<vtkPolyData> landmarkPolyData;
@@ -720,7 +720,7 @@ void WorldView::connectDepthPipeline()
 
   if (!d->inputDepthGeometryFilter)
   {
-    d->depthScalarFilter->SetInputConnection(0);
+    d->depthScalarFilter->SetInputConnection(nullptr);
     return;
   }
 

--- a/gui/WorldView.h
+++ b/gui/WorldView.h
@@ -69,7 +69,7 @@ class WorldView : public QWidget
   Q_OBJECT
 
 public:
-  explicit WorldView(QWidget* parent = 0, Qt::WindowFlags flags = 0);
+  explicit WorldView(QWidget* parent = nullptr, Qt::WindowFlags flags = {});
   ~WorldView() override;
 
   void initFrameSampling(int nbFrames);

--- a/gui/tools/AbstractTool.h
+++ b/gui/tools/AbstractTool.h
@@ -141,7 +141,7 @@ public:
   };
   Q_DECLARE_FLAGS(Outputs, Output)
 
-  explicit AbstractTool(QObject* parent = 0);
+  explicit AbstractTool(QObject* parent = nullptr);
   ~AbstractTool() override;
 
   /// Get the types of output produced by the tool.
@@ -212,7 +212,7 @@ public:
   ///
   /// \return \c true if tool execution was started successfully, otherwise
   ///         \c false.
-  virtual bool execute(QWidget* window = 0);
+  virtual bool execute(QWidget* window = nullptr);
 
   /// Block until the tool has finished executing
   void wait();

--- a/gui/tools/BundleAdjustTool.h
+++ b/gui/tools/BundleAdjustTool.h
@@ -40,7 +40,7 @@ class BundleAdjustTool : public AbstractTool
   Q_OBJECT
 
 public:
-  explicit BundleAdjustTool(QObject* parent = 0);
+  explicit BundleAdjustTool(QObject* parent = nullptr);
   ~BundleAdjustTool() override;
 
   Outputs outputs() const override;
@@ -48,7 +48,7 @@ public:
   /// Get if the tool can be canceled.
   bool isCancelable() const override { return true; }
 
-  bool execute(QWidget* window = 0) override;
+  bool execute(QWidget* window = nullptr) override;
 
   bool callback_handler(camera_map_sptr cameras, landmark_map_sptr landmarks);
 

--- a/gui/tools/CanonicalTransformTool.h
+++ b/gui/tools/CanonicalTransformTool.h
@@ -40,7 +40,7 @@ class CanonicalTransformTool : public AbstractTool
   Q_OBJECT
 
 public:
-  explicit CanonicalTransformTool(QObject* parent = 0);
+  explicit CanonicalTransformTool(QObject* parent = nullptr);
   ~CanonicalTransformTool() override;
 
   Outputs outputs() const override;
@@ -48,7 +48,7 @@ public:
   /// Get if the tool can be canceled.
   bool isCancelable() const override { return false; }
 
-  bool execute(QWidget* window = 0) override;
+  bool execute(QWidget* window = nullptr) override;
 
 protected:
   void run() override;

--- a/gui/tools/ComputeAllDepthTool.h
+++ b/gui/tools/ComputeAllDepthTool.h
@@ -40,15 +40,15 @@ class ComputeAllDepthTool : public AbstractTool
   Q_OBJECT
 
 public:
-  explicit ComputeAllDepthTool(QObject* parent = 0);
+  explicit ComputeAllDepthTool(QObject* parent = nullptr);
   virtual ~ComputeAllDepthTool();
 
-  virtual Outputs outputs() const QTE_OVERRIDE;
+  virtual Outputs outputs() const override;
 
   /// Get if the tool can be canceled.
-  virtual bool isCancelable() const QTE_OVERRIDE { return true; }
+  virtual bool isCancelable() const override { return true; }
 
-  virtual bool execute(QWidget* window = 0) QTE_OVERRIDE;
+  virtual bool execute(QWidget* window = nullptr) override;
 
   bool callback_handler(kwiver::vital::image_container_sptr depth,
                         std::string const& status,

--- a/gui/tools/ComputeDepthTool.h
+++ b/gui/tools/ComputeDepthTool.h
@@ -40,7 +40,7 @@ class ComputeDepthTool : public AbstractTool
   Q_OBJECT
 
 public:
-  explicit ComputeDepthTool(QObject* parent = 0);
+  explicit ComputeDepthTool(QObject* parent = nullptr);
   ~ComputeDepthTool() override;
 
   Outputs outputs() const override;
@@ -48,7 +48,7 @@ public:
   /// Get if the tool can be canceled.
   bool isCancelable() const override { return true; }
 
-  bool execute(QWidget* window = 0) override;
+  bool execute(QWidget* window = nullptr) override;
 
   bool callback_handler(kwiver::vital::image_container_sptr depth,
                         std::string const& status,

--- a/gui/tools/FuseDepthTool.h
+++ b/gui/tools/FuseDepthTool.h
@@ -40,18 +40,18 @@ class FuseDepthTool : public AbstractTool
   Q_OBJECT
 
 public:
-  explicit FuseDepthTool(QObject* parent = 0);
+  explicit FuseDepthTool(QObject* parent = nullptr);
   virtual ~FuseDepthTool();
 
-  virtual Outputs outputs() const QTE_OVERRIDE;
+  virtual Outputs outputs() const override;
 
   /// Get if the tool can be canceled.
-  virtual bool isCancelable() const QTE_OVERRIDE { return true; }
+  virtual bool isCancelable() const override { return true; }
 
-  virtual bool execute(QWidget* window = 0) QTE_OVERRIDE;
+  virtual bool execute(QWidget* window = nullptr) override;
 
 protected:
-  virtual void run() QTE_OVERRIDE;
+  virtual void run() override;
 
 private:
   QTE_DECLARE_PRIVATE_RPTR(FuseDepthTool)

--- a/gui/tools/InitCamerasLandmarksTool.h
+++ b/gui/tools/InitCamerasLandmarksTool.h
@@ -40,7 +40,7 @@ class InitCamerasLandmarksTool : public AbstractTool
   Q_OBJECT
 
 public:
-  explicit InitCamerasLandmarksTool(QObject* parent = 0);
+  explicit InitCamerasLandmarksTool(QObject* parent = nullptr);
   ~InitCamerasLandmarksTool() override;
 
   Outputs outputs() const override;
@@ -48,7 +48,7 @@ public:
   /// Get if the tool can be canceled.
   bool isCancelable() const override { return true; }
 
-  bool execute(QWidget* window = 0) override;
+  bool execute(QWidget* window = nullptr) override;
 
   bool callback_handler(camera_map_sptr cameras, landmark_map_sptr landmarks,
                         feature_track_set_changes_sptr track_changes);

--- a/gui/tools/NeckerReversalTool.h
+++ b/gui/tools/NeckerReversalTool.h
@@ -38,7 +38,7 @@ class NeckerReversalTool : public AbstractTool
   Q_OBJECT
 
 public:
-  explicit NeckerReversalTool(QObject* parent = 0);
+  explicit NeckerReversalTool(QObject* parent = nullptr);
   ~NeckerReversalTool() override;
 
   Outputs outputs() const override;
@@ -46,7 +46,7 @@ public:
   /// Get if the tool can be canceled.
   bool isCancelable() const override { return false; }
 
-  bool execute(QWidget* window = 0) override;
+  bool execute(QWidget* window = nullptr) override;
 
 protected:
   void run() override;

--- a/gui/tools/RunAllTool.cxx
+++ b/gui/tools/RunAllTool.cxx
@@ -51,13 +51,8 @@
 class RunAllToolPrivate
 {
 public:
-  RunAllToolPrivate()
-    : output(0), failed(false)
-  {
-  }
-
   AbstractTool::Outputs output;
-  bool failed;
+  bool failed = false;
 
   std::unique_ptr<TrackFeaturesTool> tracker;
   std::unique_ptr<InitCamerasLandmarksTool> initializer;

--- a/gui/tools/RunAllTool.h
+++ b/gui/tools/RunAllTool.h
@@ -40,7 +40,7 @@ class RunAllTool : public AbstractTool
   Q_OBJECT
 
 public:
-  explicit RunAllTool(QObject* parent = 0);
+  explicit RunAllTool(QObject* parent = nullptr);
   ~RunAllTool() override;
 
   Outputs outputs() const override;
@@ -48,7 +48,7 @@ public:
   /// Get if the tool can be canceled.
   bool isCancelable() const override { return true; }
 
-  bool execute(QWidget* window = 0) override;
+  bool execute(QWidget* window = nullptr) override;
 
 public slots:
   void cancel() override;

--- a/gui/tools/SaveFrameTool.h
+++ b/gui/tools/SaveFrameTool.h
@@ -40,7 +40,7 @@ class SaveFrameTool : public AbstractTool
   Q_OBJECT
 
 public:
-  explicit SaveFrameTool(QObject* parent = 0);
+  explicit SaveFrameTool(QObject* parent = nullptr);
   ~SaveFrameTool() override;
 
   Outputs outputs() const override;
@@ -48,7 +48,7 @@ public:
   /// Get if the tool can be canceled.
   bool isCancelable() const override { return true; }
 
-  bool execute(QWidget* window = 0) override;
+  bool execute(QWidget* window = nullptr) override;
 
 protected:
   void run() override;

--- a/gui/tools/SaveKeyFrameTool.h
+++ b/gui/tools/SaveKeyFrameTool.h
@@ -40,7 +40,7 @@ class SaveKeyFrameTool : public AbstractTool
   Q_OBJECT
 
 public:
-  explicit SaveKeyFrameTool(QObject* parent = 0);
+  explicit SaveKeyFrameTool(QObject* parent = nullptr);
   ~SaveKeyFrameTool() override;
 
   Outputs outputs() const override;
@@ -48,7 +48,7 @@ public:
   /// Get if the tool can be canceled.
   bool isCancelable() const override { return true; }
 
-  bool execute(QWidget* window = 0) override;
+  bool execute(QWidget* window = nullptr) override;
 
 protected:
   void run() override;

--- a/gui/tools/TrackFeaturesSprokitTool.h
+++ b/gui/tools/TrackFeaturesSprokitTool.h
@@ -41,19 +41,19 @@ class TrackFeaturesSprokitTool : public AbstractTool
   Q_OBJECT
 
 public:
-  explicit TrackFeaturesSprokitTool(QObject* parent = 0);
+  explicit TrackFeaturesSprokitTool(QObject* parent = nullptr);
   ~TrackFeaturesSprokitTool() override;
   Outputs outputs() const override;
 
   /// Get if the tool can be canceled.
   bool isCancelable() const override { return true; }
 
-  bool execute(QWidget* window = 0) override;
+  bool execute(QWidget* window = nullptr) override;
 
 protected:
   void run() override;
 
-  virtual std::string create_pipeline_config(QWidget* window = 0);
+  virtual std::string create_pipeline_config(QWidget* window = nullptr);
 
 private:
   QTE_DECLARE_PRIVATE_RPTR(TrackFeaturesSprokitTool)

--- a/gui/tools/TrackFeaturesTool.h
+++ b/gui/tools/TrackFeaturesTool.h
@@ -40,7 +40,7 @@ class TrackFeaturesTool : public AbstractTool
   Q_OBJECT
 
 public:
-  explicit TrackFeaturesTool(QObject* parent = 0);
+  explicit TrackFeaturesTool(QObject* parent = nullptr);
   ~TrackFeaturesTool() override;
 
   Outputs outputs() const override;
@@ -48,7 +48,7 @@ public:
   /// Get if the tool can be canceled.
   bool isCancelable() const override { return true; }
 
-  bool execute(QWidget* window = 0) override;
+  bool execute(QWidget* window = nullptr) override;
 
 protected:
   void run() override;

--- a/gui/tools/TrackFilterTool.h
+++ b/gui/tools/TrackFilterTool.h
@@ -40,7 +40,7 @@ class TrackFilterTool : public AbstractTool
   Q_OBJECT
 
 public:
-  explicit TrackFilterTool(QObject* parent = 0);
+  explicit TrackFilterTool(QObject* parent = nullptr);
   ~TrackFilterTool() override;
 
   Outputs outputs() const override;
@@ -48,7 +48,7 @@ public:
   /// Get if the tool can be canceled.
   bool isCancelable() const override { return false; }
 
-  bool execute(QWidget* window = 0) override;
+  bool execute(QWidget* window = nullptr) override;
 
 protected:
   void run() override;

--- a/gui/tools/TriangulateTool.h
+++ b/gui/tools/TriangulateTool.h
@@ -40,7 +40,7 @@ class TriangulateTool : public AbstractTool
   Q_OBJECT
 
 public:
-  explicit TriangulateTool(QObject* parent = 0);
+  explicit TriangulateTool(QObject* parent = nullptr);
   ~TriangulateTool() override;
 
   Outputs outputs() const override;
@@ -48,7 +48,7 @@ public:
   /// Get if the tool can be canceled.
   bool isCancelable() const override { return false; }
 
-  bool execute(QWidget* window = 0) override;
+  bool execute(QWidget* window = nullptr) override;
 
 protected:
   void run() override;

--- a/gui/vtkMaptkCameraRepresentation.cxx
+++ b/gui/vtkMaptkCameraRepresentation.cxx
@@ -180,9 +180,9 @@ vtkMaptkCameraRepresentation::vtkMaptkCameraRepresentation()
   this->NonActiveCameraRepLength = 4.0;
   this->DisplayDensity = 1;
 
-  this->ActiveCamera = 0;
+  this->ActiveCamera = nullptr;
 
-  this->Internal->LastActiveCamera = 0;
+  this->Internal->LastActiveCamera = nullptr;
   this->Internal->LastNonActiveCameraRepLength = -1.0;
   this->Internal->PathNeedsUpdate = false;
 
@@ -270,7 +270,7 @@ void vtkMaptkCameraRepresentation::RemoveCamera(int id)
 
   if (this->ActiveCamera == camIter->second)
   {
-    this->ActiveCamera = 0;
+    this->ActiveCamera = nullptr;
   }
 
   camIter->second->UnRegister(this);

--- a/gui/vtkMaptkImageDataGeometryFilter.cxx
+++ b/gui/vtkMaptkImageDataGeometryFilter.cxx
@@ -76,10 +76,10 @@ public:
 vtkMaptkImageDataGeometryFilter::vtkMaptkImageDataGeometryFilter()
   : Internal(new vtkInternal)
 {
-  this->ThresholdCells  = 0;
+  this->ThresholdCells = 0;
   this->GenerateTriangleOutput = 0;
 
-  this->UnprojectedPointArrayName = 0;
+  this->UnprojectedPointArrayName = nullptr;
   this->SetUnprojectedPointArrayName("Points");
 
   this->SetNumberOfOutputPorts(3);
@@ -88,7 +88,7 @@ vtkMaptkImageDataGeometryFilter::vtkMaptkImageDataGeometryFilter()
 //-----------------------------------------------------------------------------
 vtkMaptkImageDataGeometryFilter::~vtkMaptkImageDataGeometryFilter()
 {
-  this->SetUnprojectedPointArrayName(0);
+  this->SetUnprojectedPointArrayName(nullptr);
 }
 
 //-----------------------------------------------------------------------------
@@ -139,7 +139,7 @@ int vtkMaptkImageDataGeometryFilter::RequestData(
   vtkPolyData* outputUnprojected = vtkPolyData::GetData(outputVector, 1);
   vtkPolyData* outputUnprojectedPolys = vtkPolyData::GetData(outputVector, 2);
 
-  vtkPoints *newPts=0;
+  vtkPoints *newPts = nullptr;
   vtkDebugMacro(<< "Extracting structured points geometry");
 
   // Output points are the full set of image points (and retain all PointData);

--- a/gui/vtkMaptkImageUnprojectDepth.cxx
+++ b/gui/vtkMaptkImageUnprojectDepth.cxx
@@ -46,21 +46,21 @@ vtkCxxSetObjectMacro(vtkMaptkImageUnprojectDepth,
 //-----------------------------------------------------------------------------
 vtkMaptkImageUnprojectDepth::vtkMaptkImageUnprojectDepth()
 {
-  this->Camera = 0;
+  this->Camera = nullptr;
 
-  this->DepthArrayName = 0;
+  this->DepthArrayName = nullptr;
   this->SetDepthArrayName("Depths");
 
-  this->UnprojectedPointArrayName = 0;
+  this->UnprojectedPointArrayName = nullptr;
   this->SetUnprojectedPointArrayName("Points");
 }
 
 //-----------------------------------------------------------------------------
 vtkMaptkImageUnprojectDepth::~vtkMaptkImageUnprojectDepth()
 {
-  this->SetCamera(0);
-  this->SetDepthArrayName(0);
-  this->SetUnprojectedPointArrayName(0);
+  this->SetCamera(nullptr);
+  this->SetDepthArrayName(nullptr);
+  this->SetUnprojectedPointArrayName(nullptr);
 }
 
 //-----------------------------------------------------------------------------

--- a/gui/vtkMaptkScalarDataFilter.cxx
+++ b/gui/vtkMaptkScalarDataFilter.cxx
@@ -40,13 +40,13 @@ vtkStandardNewMacro(vtkMaptkScalarDataFilter);
 //----------------------------------------------------------------------------
 vtkMaptkScalarDataFilter::vtkMaptkScalarDataFilter()
 {
-  this->ScalarArrayName = 0;
+  this->ScalarArrayName = nullptr;
 }
 
 //----------------------------------------------------------------------------
 vtkMaptkScalarDataFilter::~vtkMaptkScalarDataFilter()
 {
-  this->SetScalarArrayName(0);
+  this->SetScalarArrayName(nullptr);
 }
 //----------------------------------------------------------------------------
 int vtkMaptkScalarDataFilter::RequestData(

--- a/gui/vtkMaptkScalarsToGradient.cxx
+++ b/gui/vtkMaptkScalarsToGradient.cxx
@@ -66,7 +66,7 @@ GetValue typedGetValue(int type)
   {
     vtkTemplateAliasMacro(return &getValue<VTK_TT>);
     default:
-      return 0;
+      return nullptr;
   }
 }
 


### PR DESCRIPTION
Update uses of literal `0` that should instead be `nullptr`. Update uses of literal `0` used with QFlags that should instead be a default-constructed object. Replace some lingering `QTE_OVERRIDE` with `override`. Fix some minor style issues. Replace some otherwise-unnecessary constructors with inline member initializers.

This fixes various deprecation warnings.