### PR TITLE
Preliminary GCP refactoring for registration points

### DIFF
--- a/gui/GroundControlPointsHelper.h
+++ b/gui/GroundControlPointsHelper.h
@@ -48,6 +48,9 @@ class GroundControlPointsHelper : public QObject
   Q_OBJECT
 
 public:
+  using id_t = kwiver::vital::ground_control_point_id_t;
+  using gcp_sptr = kwiver::vital::ground_control_point_sptr;
+
   GroundControlPointsHelper(QObject* parent = nullptr);
   ~GroundControlPointsHelper();
 
@@ -56,15 +59,17 @@ public:
   // Call this function when the GCP data has been modified
   void updateViewsFromGCPs();
 
+  bool isEmpty() const;
+  std::vector<id_t> identifiers() const;
+
   // Set ground control points
   void setGroundControlPoints(kwiver::vital::ground_control_point_map const&);
+
   // Get access to the ground control points
-  kwiver::vital::ground_control_point_map::ground_control_point_map_t const&
-  groundControlPoints() const;
+  std::vector<gcp_sptr> groundControlPoints() const;
 
   // Get access to a single ground control point
-  kwiver::vital::ground_control_point_sptr groundControlPoint(
-    kwiver::vital::ground_control_point_id_t pointId);
+  gcp_sptr groundControlPoint(id_t pointId);
 
   bool readGroundControlPoints(QString const& path);
 
@@ -76,10 +81,10 @@ public slots:
 
   void recomputePoints();
 
-  void resetPoint(kwiver::vital::ground_control_point_id_t);
-  void removePoint(kwiver::vital::ground_control_point_id_t);
+  void resetPoint(id_t);
+  void removePoint(id_t);
 
-  void setActivePoint(kwiver::vital::ground_control_point_id_t);
+  void setActivePoint(id_t);
 
   void applySimilarityTransform();
 
@@ -87,11 +92,11 @@ signals:
   void pointsReloaded();
   void pointsRecomputed();
   void pointCountChanged(size_t);
-  void pointAdded(kwiver::vital::ground_control_point_id_t);
-  void pointRemoved(kwiver::vital::ground_control_point_id_t);
-  void pointChanged(kwiver::vital::ground_control_point_id_t);
+  void pointAdded(id_t);
+  void pointRemoved(id_t);
+  void pointChanged(id_t);
 
-  void activePointChanged(kwiver::vital::ground_control_point_id_t);
+  void activePointChanged(id_t);
 
 protected slots:
   void addCameraViewPoint();

--- a/gui/GroundControlPointsModel.h
+++ b/gui/GroundControlPointsModel.h
@@ -37,6 +37,8 @@
 
 #include <QAbstractItemModel>
 
+class GroundControlPointsHelper;
+
 class GroundControlPointsModelPrivate;
 
 class GroundControlPointsModel : public QAbstractItemModel
@@ -66,8 +68,7 @@ public:
   QVariant headerData(int section, Qt::Orientation orientation,
                       int role) const override;
 
-  void setPointData(std::map<kwiver::vital::ground_control_point_id_t,
-                             kwiver::vital::ground_control_point_sptr> const&);
+  void setDataSource(GroundControlPointsHelper*);
 
   void setRegisteredIcon(QIcon const& icon);
 

--- a/gui/GroundControlPointsView.cxx
+++ b/gui/GroundControlPointsView.cxx
@@ -447,7 +447,7 @@ void GroundControlPointsView::setHelper(GroundControlPointsHelper* helper)
   connect(helper, &GroundControlPointsHelper::pointsReloaded,
           &d->model, &GroundControlPointsModel::resetPoints);
 
-  d->model.setPointData(helper->groundControlPoints());
+  d->model.setDataSource(helper);
 }
 
 //-----------------------------------------------------------------------------

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -497,7 +497,7 @@ void MainWindowPrivate::shiftGeoOrigin(kv::vector_3d const& offset)
   // shift the GCPs
   for (auto gcp : this->groundControlPointsHelper->groundControlPoints())
   {
-    gcp.second->set_loc(gcp.second->loc() - offset);
+    gcp->set_loc(gcp->loc() - offset);
   }
   this->groundControlPointsHelper->updateViewsFromGCPs();
 }
@@ -2214,7 +2214,7 @@ void MainWindow::loadGroundControlPoints(QString const& path)
   if (d->groundControlPointsHelper->readGroundControlPoints(path))
   {
     d->UI.actionExportGroundControlPoints->setEnabled(
-      d->groundControlPointsHelper->groundControlPoints().size());
+      !d->groundControlPointsHelper->isEmpty());
   }
 }
 
@@ -3195,12 +3195,12 @@ void MainWindow::applySimilarityTransform()
   QTE_D();
 
   std::vector<kwiver::vital::ground_control_point_sptr> gcps;
-  auto gcp_map = d->groundControlPointsHelper->groundControlPoints();
-  for (auto gcp : gcp_map)
+  auto const& allGcps = d->groundControlPointsHelper->groundControlPoints();
+  for (auto const& gcp : allGcps)
   {
-    if (gcp.second->is_geo_loc_user_provided())
+    if (gcp->is_geo_loc_user_provided())
     {
-      gcps.push_back(gcp.second);
+      gcps.push_back(gcp);
     }
   }
 
@@ -3294,10 +3294,10 @@ void MainWindow::applySimilarityTransform()
   d->updateCameras(camera_map);
 
   // Transform GCP's
-  for (auto gcp : gcp_map)
+  for (auto gcp : allGcps)
   {
-    auto gcp_loc = gcp.second->loc();
-    gcp.second->set_loc(sim_transform * gcp_loc);
+    auto gcp_loc = gcp->loc();
+    gcp->set_loc(sim_transform * gcp_loc);
   }
   d->groundControlPointsHelper->updateViewsFromGCPs();
 


### PR DESCRIPTION
Refactor `GroundControlPointsHelper` in order to start preparing for this class to also manage registration points. We need these to be managed by a single class in order to have a centralized location for managing the identifiers, since we eventually want to be able to add registration points before they have an associated ground control point.

Also, refactor users so that the internal map is no longer directly accessible, as the value type of said map is now a private type. Certain batch operations (such as resetting the GCP view) may be somewhat less efficient as a result, but efficiency on the whole should be similar, and the operations most impacted are not believed to be major bottlenecks.

Last, make the world and camera view GCP widgets members of the helper's private class. This allows us to simplify the many, many places we previously needed to look these up, which requires a very lengthy invocation.

----

I'm pushing these changes early as the refactoring seems more likely to be problematic than the mostly-adding-things changes that will also be needed for registration points. The goal is to provide an earlier opportunity to start looking over and potentially poking at these.