### PR TITLE
Consistently use frame_id_t

### DIFF
--- a/gui/CameraView.cxx
+++ b/gui/CameraView.cxx
@@ -619,7 +619,7 @@ void CameraView::setImageData(vtkImageData* data, QSize dimensions)
 }
 
 //-----------------------------------------------------------------------------
-void CameraView::setActiveFrame(unsigned frame)
+void CameraView::setActiveFrame(kwiver::vital::frame_id_t frame)
 {
   QTE_D();
 

--- a/gui/CameraView.h
+++ b/gui/CameraView.h
@@ -68,7 +68,7 @@ public slots:
 
   void setLandmarksData(kwiver::vital::landmark_map const&);
 
-  void setActiveFrame(unsigned);
+  void setActiveFrame(kwiver::vital::frame_id_t);
 
   void addLandmark(kwiver::vital::landmark_id_t id, double x, double y);
   void addResidual(kwiver::vital::track_id_t id,

--- a/gui/ColorizeSurfaceOptions.cxx
+++ b/gui/ColorizeSurfaceOptions.cxx
@@ -71,7 +71,7 @@ public:
   QString krtdFile;
   QString frameFile;
 
-  int currentFrame;
+  kwiver::vital::frame_id_t currentFrame;
 };
 
 QTE_IMPLEMENT_D_FUNC(ColorizeSurfaceOptions)
@@ -163,7 +163,7 @@ int ColorizeSurfaceOptions::getFrameSampling() const
 }
 
 //-----------------------------------------------------------------------------
-void ColorizeSurfaceOptions::setCurrentFrame(int frame)
+void ColorizeSurfaceOptions::setCurrentFrame(kwiver::vital::frame_id_t frame)
 {
   QTE_D();
 
@@ -317,8 +317,8 @@ void ColorizeSurfaceOptions::colorize()
   if (! this->InsideColorize)
   {
     this->InsideColorize = true;
-    int colorizedFrame = (d->UI.radioButtonCurrentFrame->isChecked()) ?
-      d->currentFrame : -1;
+    auto colorizedFrame =
+      (d->UI.radioButtonCurrentFrame->isChecked() ? d->currentFrame : -1);
     while (this->LastColorizedFrame != colorizedFrame)
     {
       this->LastColorizedFrame = colorizedFrame;

--- a/gui/ColorizeSurfaceOptions.h
+++ b/gui/ColorizeSurfaceOptions.h
@@ -58,7 +58,7 @@ public:
   void initFrameSampling(int nbFrames);
   int getFrameSampling() const;
 
-  void setCurrentFrame(int frame);
+  void setCurrentFrame(kwiver::vital::frame_id_t frame);
   void setOcclusionThreshold(double occlusionThreshold)
   {
     this->OcclusionThreshold = occlusionThreshold;
@@ -111,7 +111,7 @@ protected:
   bool RemoveMasked;
   bool InsideColorize;
   const int INVALID_FRAME = -2;
-  int LastColorizedFrame;
+  kwiver::vital::frame_id_t LastColorizedFrame;
 
 private:
 

--- a/gui/MainWindow.h
+++ b/gui/MainWindow.h
@@ -60,11 +60,11 @@ public:
   ~MainWindow() override;
 
   kwiver::arrows::vtk::vtkKwiverCamera* activeCamera();
+
   WorldView* worldView();
   CameraView* cameraView();
-  kwiver::vital::local_geo_cs localGeoCoordinateSystem() const;
 
-  void applySimilarityTransform();
+  kwiver::vital::local_geo_cs localGeoCoordinateSystem() const;
 
 public slots:
   void newProject();
@@ -104,6 +104,7 @@ public slots:
   void saveToolResults();
   void acceptToolSaveResults(std::shared_ptr<ToolData> data);
 
+  void applySimilarityTransform();
 
   void saveWebGLScene();
 
@@ -114,7 +115,7 @@ public slots:
 
   void enableSaveDepthPoints(bool);
 
-  void setActiveCamera(int);
+  void setActiveFrame(kwiver::vital::frame_id_t);
 
   void setViewBackroundColor();
 

--- a/gui/VolumeOptions.cxx
+++ b/gui/VolumeOptions.cxx
@@ -234,7 +234,7 @@ void VolumeOptions::forceColorize()
 }
 
 //-----------------------------------------------------------------------------
-void VolumeOptions::setCurrentFrame(int frame)
+void VolumeOptions::setCurrentFrame(kwiver::vital::frame_id_t frame)
 {
   QTE_D();
 

--- a/gui/VolumeOptions.h
+++ b/gui/VolumeOptions.h
@@ -73,7 +73,7 @@ public:
   void colorize();
   void forceColorize();
 
-  void setCurrentFrame(int);
+  void setCurrentFrame(kwiver::vital::frame_id_t);
 
   bool isColorOptionsEnabled();
 

--- a/gui/WorldView.cxx
+++ b/gui/WorldView.cxx
@@ -955,7 +955,7 @@ void WorldView::setVolumeVisible(bool state)
 }
 
 //-----------------------------------------------------------------------------
-void WorldView::setVolumeCurrentFrame(int frame)
+void WorldView::setVolumeCurrentFrame(kwiver::vital::frame_id_t frame)
 {
   QTE_D();
 
@@ -976,7 +976,8 @@ void WorldView::computeContour(double threshold)
 }
 
 //-----------------------------------------------------------------------------
-void WorldView::addCamera(int id, kwiver::arrows::vtk::vtkKwiverCamera* camera)
+void WorldView::addCamera(
+  kwiver::vital::frame_id_t id, kwiver::arrows::vtk::vtkKwiverCamera* camera)
 {
   Q_UNUSED(id)
 
@@ -989,17 +990,15 @@ void WorldView::addCamera(int id, kwiver::arrows::vtk::vtkKwiverCamera* camera)
 }
 
 //-----------------------------------------------------------------------------
-void WorldView::removeCamera(int id)
+void WorldView::removeCamera(kwiver::vital::frame_id_t id)
 {
-  Q_UNUSED(id)
-
-    QTE_D();
+  QTE_D();
 
   d->cameraRep->RemoveCamera(id);
 }
 
 //-----------------------------------------------------------------------------
-void WorldView::setActiveCamera(int id)
+void WorldView::setActiveCamera(kwiver::vital::frame_id_t id)
 {
   static auto const plane = kwiver::vital::vector_4d(0.0, 0.0, 1.0, 0.0);
 

--- a/gui/WorldView.h
+++ b/gui/WorldView.h
@@ -106,8 +106,9 @@ signals:
 public slots:
   void setBackgroundColor(QColor const&);
 
-  void addCamera(int id, kwiver::arrows::vtk::vtkKwiverCamera* camera);
-  void removeCamera(int id);
+  void addCamera(kwiver::vital::frame_id_t id,
+                 kwiver::arrows::vtk::vtkKwiverCamera* camera);
+  void removeCamera(kwiver::vital::frame_id_t id);
   void setLandmarks(kwiver::vital::landmark_map const&);
 
   void setValidDepthInput(bool);
@@ -128,7 +129,7 @@ public slots:
 
   void setPerspective(bool);
 
-  void setActiveCamera(int id);
+  void setActiveCamera(kwiver::vital::frame_id_t id);
 
   void queueResetView();
   void resetView();
@@ -154,7 +155,7 @@ public slots:
   void invalidateGeometry();
 
   void setVolumeVisible(bool);
-  void setVolumeCurrentFrame(int);
+  void setVolumeCurrentFrame(kwiver::vital::frame_id_t);
 
   void computeContour(double threshold);
   void render();

--- a/gui/tools/AbstractTool.cxx
+++ b/gui/tools/AbstractTool.cxx
@@ -195,7 +195,7 @@ std::shared_ptr<ToolData> AbstractTool::data()
 }
 
 //-----------------------------------------------------------------------------
-unsigned int AbstractTool::activeFrame() const
+kwiver::vital::frame_id_t AbstractTool::activeFrame() const
 {
   QTE_D();
   return d->data->activeFrame;
@@ -272,14 +272,14 @@ AbstractTool::fusion_sptr AbstractTool::volume() const
 }
 
 //-----------------------------------------------------------------------------
-void AbstractTool::setActiveFrame(unsigned int frame)
+void AbstractTool::setActiveFrame(kwiver::vital::frame_id_t frame)
 {
   QTE_D();
   d->data->activeFrame = frame;
 }
 
 //-----------------------------------------------------------------------------
-void AbstractTool::setLastFrame(int count)
+void AbstractTool::setLastFrame(kwiver::vital::frame_id_t count)
 {
   QTE_D();
   d->data->maxFrame = count;

--- a/gui/tools/AbstractTool.h
+++ b/gui/tools/AbstractTool.h
@@ -93,8 +93,8 @@ public:
            !cameras && !landmarks && !volume;
   }
 
-  int maxFrame;
-  unsigned int activeFrame;
+  kwiver::vital::frame_id_t maxFrame;
+  kwiver::vital::frame_id_t activeFrame;
   std::string videoPath;
   std::string maskPath;
   feature_track_set_sptr tracks;
@@ -158,7 +158,7 @@ public:
   std::shared_ptr<ToolData> data();
 
   /// Set the active frame to be used by the tool.
-  void setActiveFrame(unsigned int frame);
+  void setActiveFrame(kwiver::vital::frame_id_t frame);
 
   /// Set the frame number of the last frame.
   ///
@@ -167,7 +167,7 @@ public:
   /// progress, since this value is expected to be known by the caller, but may
   /// be expensive for the tool to determine. This does \em not affect how many
   /// frames the tool will actually process.
-  void setLastFrame(int);
+  void setLastFrame(kwiver::vital::frame_id_t);
 
   /// Set the feature tracks to be used as input to the tool.
   void setTracks(feature_track_set_sptr const&);
@@ -218,7 +218,7 @@ public:
   void wait();
 
   /// Get the active frame.
-  unsigned int activeFrame() const;
+  kwiver::vital::frame_id_t activeFrame() const;
 
   std::shared_ptr<std::map<kwiver::vital::frame_id_t, std::string> > depthLookup() const;
   vtkBox *ROI() const;

--- a/gui/vtkMaptkCameraRepresentation.cxx
+++ b/gui/vtkMaptkCameraRepresentation.cxx
@@ -31,8 +31,8 @@
 #include "vtkMaptkCameraRepresentation.h"
 
 #include "arrows/vtk/vtkKwiverCamera.h"
-#include <vital/types/vector.h>
 
+#include <vital/types/vector.h>
 
 #include <vtkActor.h>
 #include <vtkAppendPolyData.h>
@@ -154,7 +154,7 @@ class vtkMaptkCameraRepresentation::vtkInternal
 public:
   vtkCamera* NextCamera();
 
-  std::map<int, vtkCamera*> Cameras;
+  std::map<kwiver::vital::frame_id_t, vtkCamera*> Cameras;
 
   vtkNew<vtkPolyData> ActivePolyData;
   vtkNew<vtkAppendPolyData> NonActiveAppendPolyData;
@@ -236,7 +236,8 @@ vtkMaptkCameraRepresentation::~vtkMaptkCameraRepresentation()
 }
 
 //-----------------------------------------------------------------------------
-void vtkMaptkCameraRepresentation::AddCamera(int id, vtkCamera* camera)
+void vtkMaptkCameraRepresentation::AddCamera(
+  kwiver::vital::frame_id_t id, vtkCamera* camera)
 {
   // Don't allow null or duplicate entries
   if (!camera || this->Internal->Cameras.count(id) > 0)
@@ -251,7 +252,7 @@ void vtkMaptkCameraRepresentation::AddCamera(int id, vtkCamera* camera)
 }
 
 //-----------------------------------------------------------------------------
-void vtkMaptkCameraRepresentation::RemoveCamera(int id)
+void vtkMaptkCameraRepresentation::RemoveCamera(kwiver::vital::frame_id_t id)
 {
   // If item isn't present, do nothing
   auto camIter = this->Internal->Cameras.find(id);
@@ -288,7 +289,8 @@ void vtkMaptkCameraRepresentation::CamerasModified()
 }
 
 //-----------------------------------------------------------------------------
-void vtkMaptkCameraRepresentation::SetActiveCamera(int id)
+void vtkMaptkCameraRepresentation::SetActiveCamera(
+  kwiver::vital::frame_id_t id)
 {
   auto camIter = this->Internal->Cameras.find(id);
   if (camIter == this->Internal->Cameras.end())

--- a/gui/vtkMaptkCameraRepresentation.h
+++ b/gui/vtkMaptkCameraRepresentation.h
@@ -31,6 +31,8 @@
 #ifndef TELESCULPTOR_VTKMAPTKCAMERAREPRESENTATION_H_
 #define TELESCULPTOR_VTKMAPTKCAMERAREPRESENTATION_H_
 
+#include <vital/vital_types.h>
+
 #include <vtkCamera.h>
 #include <vtkCollection.h>
 #include <vtkSmartPointer.h>
@@ -47,15 +49,15 @@ public:
 
   static vtkMaptkCameraRepresentation* New();
 
-  void AddCamera(int id, vtkCamera* camera);
-  void RemoveCamera(int id);
+  void AddCamera(kwiver::vital::frame_id_t id, vtkCamera* camera);
+  void RemoveCamera(kwiver::vital::frame_id_t id);
 
   // Mark the existing cameras as modified
   void CamerasModified();
 
   // Description:
   // Get/Set the camera to be displayed as the active camera
-  void SetActiveCamera(int id);
+  void SetActiveCamera(kwiver::vital::frame_id_t id);
   vtkGetObjectMacro(ActiveCamera, vtkCamera);
 
   // Description:

--- a/gui/vtkMaptkFeatureTrackRepresentation.cxx
+++ b/gui/vtkMaptkFeatureTrackRepresentation.cxx
@@ -48,9 +48,9 @@ typedef vtkMaptkFeatureTrackRepresentation::TrailStyleEnum TrailStyleEnum;
 class vtkMaptkFeatureTrackRepresentation::vtkInternal
 {
 public:
-  void UpdateActivePoints(unsigned activeFrame);
-  void UpdateTrails(unsigned activeFrame, unsigned trailLength,
-                    TrailStyleEnum style);
+  void UpdateActivePoints(kwiver::vital::frame_id_t activeFrame);
+  void UpdateTrails(kwiver::vital::frame_id_t activeFrame,
+                    unsigned trailLength, TrailStyleEnum style);
 
   vtkNew<vtkPoints> PointsWithDesc;
   vtkNew<vtkPoints> PointsWithoutDesc;
@@ -66,8 +66,8 @@ public:
   vtkNew<vtkPolyData> TrailsWithDescPolyData;
   vtkNew<vtkPolyData> TrailsWithoutDescPolyData;
 
-  typedef std::map<unsigned, vtkIdType> TrackType;
-  typedef std::map<unsigned, TrackType> TrackMapType;
+  using TrackType    = std::map<kwiver::vital::frame_id_t, vtkIdType>;
+  using TrackMapType = std::map<kwiver::vital::track_id_t, TrackType>;
 
   TrackMapType TracksWithDesc;
   TrackMapType TracksWithoutDesc;
@@ -75,7 +75,7 @@ public:
 
 //-----------------------------------------------------------------------------
 void vtkMaptkFeatureTrackRepresentation::vtkInternal::UpdateActivePoints(
-  unsigned activeFrame)
+  kwiver::vital::frame_id_t activeFrame)
 {
   this->PointsWithDescCells->Reset();
 
@@ -112,7 +112,8 @@ void vtkMaptkFeatureTrackRepresentation::vtkInternal::UpdateActivePoints(
 
 //-----------------------------------------------------------------------------
 void vtkMaptkFeatureTrackRepresentation::vtkInternal::UpdateTrails(
-  unsigned activeFrame, unsigned trailLength, TrailStyleEnum style)
+  kwiver::vital::frame_id_t activeFrame, unsigned trailLength,
+  TrailStyleEnum style)
 {
   this->TrailsWithDescCells->Reset();
   this->TrailsWithoutDescCells->Reset();
@@ -262,7 +263,8 @@ vtkMaptkFeatureTrackRepresentation::~vtkMaptkFeatureTrackRepresentation()
 
 //-----------------------------------------------------------------------------
 void vtkMaptkFeatureTrackRepresentation::AddTrackWithDescPoint(
-  unsigned trackId, unsigned frameId, double x, double y)
+  kwiver::vital::track_id_t trackId, kwiver::vital::frame_id_t frameId,
+  double x, double y)
 {
   auto const id = this->Internal->PointsWithDesc->InsertNextPoint(x, y, 0.0);
   this->Internal->TracksWithDesc[trackId][frameId] = id;
@@ -270,7 +272,8 @@ void vtkMaptkFeatureTrackRepresentation::AddTrackWithDescPoint(
 
 //-----------------------------------------------------------------------------
 void vtkMaptkFeatureTrackRepresentation::AddTrackWithoutDescPoint(
-  unsigned trackId, unsigned frameId, double x, double y)
+  kwiver::vital::track_id_t trackId, kwiver::vital::frame_id_t frameId,
+  double x, double y)
 {
   auto const id = this->Internal->PointsWithoutDesc->InsertNextPoint(x, y, 0.0);
   this->Internal->TracksWithoutDesc[trackId][frameId] = id;
@@ -290,7 +293,8 @@ void vtkMaptkFeatureTrackRepresentation::ClearTrackData()
 }
 
 //-----------------------------------------------------------------------------
-void vtkMaptkFeatureTrackRepresentation::SetActiveFrame(unsigned frame)
+void vtkMaptkFeatureTrackRepresentation::SetActiveFrame(
+  kwiver::vital::frame_id_t frame)
 {
   if (this->ActiveFrame == frame)
   {

--- a/gui/vtkMaptkFeatureTrackRepresentation.h
+++ b/gui/vtkMaptkFeatureTrackRepresentation.h
@@ -31,6 +31,8 @@
 #ifndef TELESCULPTOR_VTKMAPTKFEATURETRACKREPRESENTATION_H_
 #define TELESCULPTOR_VTKMAPTKFEATURETRACKREPRESENTATION_H_
 
+#include <vital/vital_types.h>
+
 #include <vtkCamera.h>
 #include <vtkCollection.h>
 #include <vtkSmartPointer.h>
@@ -53,9 +55,13 @@ public:
 
   static vtkMaptkFeatureTrackRepresentation* New();
 
-  void AddTrackWithDescPoint(unsigned trackId, unsigned frameId, double x, double y);
+  void AddTrackWithDescPoint(kwiver::vital::track_id_t trackId,
+                             kwiver::vital::frame_id_t frameId,
+                             double x, double y);
 
-  void AddTrackWithoutDescPoint(unsigned trackId, unsigned frameId, double x, double y);
+  void AddTrackWithoutDescPoint(kwiver::vital::track_id_t trackId,
+                                kwiver::vital::frame_id_t frameId,
+                                double x, double y);
 
   // Description:
   // Remove all track data
@@ -63,8 +69,8 @@ public:
 
   // Description:
   // Get/Set the active frame
-  void SetActiveFrame(unsigned);
-  vtkGetMacro(ActiveFrame, unsigned);
+  void SetActiveFrame(kwiver::vital::frame_id_t);
+  vtkGetMacro(ActiveFrame, kwiver::vital::frame_id_t);
 
   // Description:
   // Get/Set the maximum number of adjacent feature points to display as
@@ -108,7 +114,7 @@ private:
   vtkMaptkFeatureTrackRepresentation(vtkMaptkFeatureTrackRepresentation const&) = delete;
   void operator=(vtkMaptkFeatureTrackRepresentation const&) = delete;
 
-  unsigned ActiveFrame;
+  kwiver::vital::frame_id_t ActiveFrame;
   unsigned TrailLength;
   TrailStyleEnum TrailStyle;
 


### PR DESCRIPTION
Modify most uses of frame identifiers to consistently use `frame_id_t` as the data type for the same. This isn't perfect, as the UI still must use `int` in some places, but overall this should significantly improve consistency and correctness.

Additionally, rename `WorldView::setActiveCamera` to `setActiveFrame` to better distinguish between the camera object and camera/frame id. (This is also preparatory to adding a method to get the current id, which will necessarily need a different name.)
