### PR TITLE
Registration points

### DIFF
--- a/CMake/telesculptor-external-fletch.cmake
+++ b/CMake/telesculptor-external-fletch.cmake
@@ -14,7 +14,7 @@ endif()
 ExternalProject_Add(fletch
   PREFIX ${TELESCULPTOR_BINARY_DIR}
   GIT_REPOSITORY "git://github.com/Kitware/fletch.git"
-  GIT_TAG 3b86acd1ed15e566550e43a35634c35b594e0329
+  GIT_TAG cf4538470395204a2233930d66f6bf2d75550319
   #GIT_SHALLOW 1
   SOURCE_DIR ${TELESCULPTOR_EXTERNAL_DIR}/fletch
   BINARY_DIR ${TELESCULPTOR_EXTERNAL_DIR}/fletch-build
@@ -52,7 +52,7 @@ ExternalProject_Add(fletch
     -Dfletch_ENABLE_OpenCV_highgui:BOOL=ON
     -Dfletch_ENABLE_PDAL:BOOL=ON
     -Dfletch_ENABLE_PNG:BOOL=ON
-    -Dfletch_ENABLE_PROJ4:BOOL=ON
+    -Dfletch_ENABLE_PROJ:BOOL=ON
     -Dfletch_ENABLE_PostGIS:BOOL=OFF
     -Dfletch_ENABLE_PostgresSQL:BOOL=OFF
     -Dfletch_ENABLE_Protobuf:BOOL=OFF

--- a/CMake/telesculptor-external-kwiver.cmake
+++ b/CMake/telesculptor-external-kwiver.cmake
@@ -18,7 +18,7 @@ ExternalProject_Add(kwiver
   BINARY_DIR ${TELESCULPTOR_EXTERNAL_DIR}/kwiver-build
   STAMP_DIR ${TELESCULPTOR_STAMP_DIR}
   GIT_REPOSITORY "https://github.com/Kitware/kwiver.git"
-  GIT_TAG ff8da686e8c501bcad11da6997cbb7753fc41abc
+  GIT_TAG 053f5aaa9962caf3e536fba34fcc4e5dd44b709e
   #GIT_SHALLOW 1
   CMAKE_CACHE_ARGS
     -DBUILD_SHARED_LIBS:BOOL=ON

--- a/gui/CameraView.cxx
+++ b/gui/CameraView.cxx
@@ -476,6 +476,8 @@ CameraView::CameraView(QWidget* parent, Qt::WindowFlags flags)
   d->setPopup(d->UI.actionPlaceEditCRP, registrationMenu);
 
   d->registrationPointsWidget = new GroundControlPointsWidget(this);
+  d->registrationPointsWidget->setColor({128, 224, 255});
+  d->registrationPointsWidget->setSelectedColor({64, 192, 255});
   d->registrationPointsWidget->setTransformMatrix(d->transformMatrix);
 
   connect(d->UI.actionPlaceEditCRP, &QAction::toggled,

--- a/gui/CameraView.cxx
+++ b/gui/CameraView.cxx
@@ -471,12 +471,20 @@ CameraView::CameraView(QWidget* parent, Qt::WindowFlags flags)
   connect(d->landmarkOptions, &PointOptions::modified,
           this, &CameraView::render);
 
+  auto const registrationMenu = new QMenu(this);
+  registrationMenu->addAction(d->UI.actionComputeCamera);
+  d->setPopup(d->UI.actionPlaceEditCRP, registrationMenu);
+
   d->registrationPointsWidget = new GroundControlPointsWidget(this);
   d->registrationPointsWidget->setTransformMatrix(d->transformMatrix);
 
   connect(d->UI.actionPlaceEditCRP, &QAction::toggled,
           d->registrationPointsWidget,
           &GroundControlPointsWidget::enableWidget);
+
+  connect(d->UI.actionComputeCamera, &QAction::triggered,
+          this, &CameraView::cameraComputationRequested,
+          Qt::QueuedConnection);
 
   d->groundControlPointsWidget = new GroundControlPointsWidget(this);
   d->groundControlPointsWidget->setTransformMatrix(d->transformMatrix);

--- a/gui/CameraView.cxx
+++ b/gui/CameraView.cxx
@@ -235,6 +235,7 @@ public:
 
   PointOptions* landmarkOptions;
   ResidualsOptions* residualsOptions;
+  GroundControlPointsWidget* registrationPointsWidget;
   GroundControlPointsWidget* groundControlPointsWidget;
   RulerWidget* rulerWidget;
 
@@ -470,6 +471,13 @@ CameraView::CameraView(QWidget* parent, Qt::WindowFlags flags)
   connect(d->landmarkOptions, &PointOptions::modified,
           this, &CameraView::render);
 
+  d->registrationPointsWidget = new GroundControlPointsWidget(this);
+  d->registrationPointsWidget->setTransformMatrix(d->transformMatrix);
+
+  connect(d->UI.actionPlaceEditCRP, &QAction::toggled,
+          d->registrationPointsWidget,
+          &GroundControlPointsWidget::enableWidget);
+
   d->groundControlPointsWidget = new GroundControlPointsWidget(this);
   d->groundControlPointsWidget->setTransformMatrix(d->transformMatrix);
 
@@ -542,6 +550,7 @@ CameraView::CameraView(QWidget* parent, Qt::WindowFlags flags)
 #endif
   vtkNew<vtkInteractorStyleRubberBand2D> is;
   renderInteractor->SetInteractorStyle(is);
+  d->registrationPointsWidget->setInteractor(renderInteractor);
   d->groundControlPointsWidget->setInteractor(renderInteractor);
   d->rulerWidget->setInteractor(renderInteractor);
 
@@ -854,6 +863,14 @@ GroundControlPointsWidget* CameraView::groundControlPointsWidget() const
 }
 
 //-----------------------------------------------------------------------------
+GroundControlPointsWidget* CameraView::registrationPointsWidget() const
+{
+  QTE_D();
+
+  return d->registrationPointsWidget;
+}
+
+//-----------------------------------------------------------------------------
 RulerWidget* CameraView::rulerWidget() const
 {
   QTE_D();
@@ -885,11 +902,26 @@ void CameraView::enableAntiAliasing(bool enable)
 }
 
 //-----------------------------------------------------------------------------
+void CameraView::setRegistrationPointEditingEnabled(bool state)
+{
+  QTE_D();
+
+  d->UI.actionPlaceEditCRP->setEnabled(state);
+
+  if (!state)
+  {
+    d->UI.actionPlaceEditCRP->setChecked(false);
+    d->registrationPointsWidget->enableWidget(false);
+  }
+}
+
+//-----------------------------------------------------------------------------
 void CameraView::clearGroundControlPoints()
 {
   QTE_D();
 
   d->groundControlPointsWidget->clearPoints();
+  d->registrationPointsWidget->clearPoints();
   this->render();
 }
 

--- a/gui/CameraView.h
+++ b/gui/CameraView.h
@@ -57,6 +57,7 @@ public:
 
   void addFeatureTrack(kwiver::vital::track const&);
   GroundControlPointsWidget* groundControlPointsWidget() const;
+  GroundControlPointsWidget* registrationPointsWidget() const;
   RulerWidget* rulerWidget() const;
 
   void enableAntiAliasing(bool enable);
@@ -67,6 +68,8 @@ public slots:
   void setImageData(vtkImageData* data, QSize dimensions);
 
   void setLandmarksData(kwiver::vital::landmark_map const&);
+
+  void setRegistrationPointEditingEnabled(bool);
 
   void setActiveFrame(kwiver::vital::frame_id_t);
 

--- a/gui/CameraView.h
+++ b/gui/CameraView.h
@@ -61,6 +61,10 @@ public:
   RulerWidget* rulerWidget() const;
 
   void enableAntiAliasing(bool enable);
+
+signals:
+  void cameraComputationRequested();
+
 public slots:
   void setBackgroundColor(QColor const&);
 

--- a/gui/CameraView.ui
+++ b/gui/CameraView.ui
@@ -226,6 +226,11 @@
     <string>Ctrl+R</string>
    </property>
   </action>
+  <action name="actionComputeCamera">
+   <property name="text">
+    <string>Compute Camera</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/gui/CameraView.ui
+++ b/gui/CameraView.ui
@@ -28,15 +28,14 @@
    </property>
    <item>
     <widget class="QToolBar" name="toolBar">
-     <property name="toolButtonStyle">
-      <enum>Qt::ToolButtonFollowStyle</enum>
-     </property>
      <addaction name="actionViewReset"/>
      <addaction name="separator"/>
      <addaction name="actionShowFrameImage"/>
      <addaction name="actionShowFeatures"/>
      <addaction name="actionShowLandmarks"/>
      <addaction name="actionShowResiduals"/>
+     <addaction name="separator"/>
+     <addaction name="actionPlaceEditCRP"/>
     </widget>
    </item>
    <item>
@@ -201,6 +200,30 @@
    </property>
    <property name="shortcut">
     <string>I</string>
+   </property>
+  </action>
+  <action name="actionPlaceEditCRP">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="icons/icons.qrc">
+     <normaloff>:/icons/22x22/location</normaloff>:/icons/22x22/location</iconset>
+   </property>
+   <property name="text">
+    <string>Edit Registration Points</string>
+   </property>
+   <property name="iconText">
+    <string>Registration Points</string>
+   </property>
+   <property name="toolTip">
+    <string>Place/edit camera registration points in the view</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+R</string>
    </property>
   </action>
  </widget>

--- a/gui/GroundControlPointsHelper.cxx
+++ b/gui/GroundControlPointsHelper.cxx
@@ -566,18 +566,25 @@ void GroundControlPointsHelperPrivate::updateActivePoint(
   int handleId, GroundControlPointsWidget* widget,
   std::map<vtkHandleWidget*, id_t> const& handleToIdMap)
 {
-  QTE_Q();
-
-  // Find the corresponding GCP ID
-  auto* const handle = widget->handleWidget(handleId);
-  if (auto* const iter = qtGet(handleToIdMap, handle))
+  if (handleId >= 0)
   {
-    emit q->activePointChanged(this->activeId = iter->second);
+    QTE_Q();
+
+    // Find the corresponding GCP ID
+    auto* const handle = widget->handleWidget(handleId);
+    if (auto* const iter = qtGet(handleToIdMap, handle))
+    {
+      emit q->activePointChanged(this->activeId = iter->second);
+    }
+    else
+    {
+      qWarning() << "Failed to find the ID associated with the handle widget"
+                << handle << "with VTK ID" << handleId;
+    }
   }
   else
   {
-    qWarning() << "Failed to find the ID associated with the handle widget"
-               << handle << "with VTK ID" << handleId;
+    this->activeId = std::numeric_limits<id_t>::max();
   }
 }
 

--- a/gui/GroundControlPointsHelper.cxx
+++ b/gui/GroundControlPointsHelper.cxx
@@ -806,7 +806,44 @@ void GroundControlPointsHelper::moveWorldViewPoint()
 //-----------------------------------------------------------------------------
 void GroundControlPointsHelper::moveRegistrationPoint()
 {
-  // TODO
+  QTE_D();
+
+  auto const handleId = d->crpWidget->activeHandle();
+  auto* const handle = d->crpWidget->handleWidget(handleId);
+
+  if (auto pid = qtGet(d->crpHandleToIdMap, handle))
+  {
+    if (auto p = qtGet(d->groundControlPoints, pid->second))
+    {
+      auto const frame = d->mainWindow->activeFrame();
+      if (auto const& s = getFeature(p->second, frame))
+      {
+        Q_ASSERT(s->feature); // Something went very wrong if this fails...
+
+        auto const& loc = d->crpWidget->activePoint();
+        auto const& feature =
+          std::dynamic_pointer_cast<kv::feature_d>(s->feature);
+
+        Q_ASSERT(feature); // Something went very wrong if this fails...
+        feature->set_loc({loc[0], loc[1]});
+      }
+      else
+      {
+        qWarning() << "No feature for ground control point with id"
+                   << *pid << "at frame" << frame;
+      }
+    }
+    else
+    {
+      qWarning() << "No ground control point with id" << *pid;
+    }
+  }
+  else
+  {
+    qWarning() << "Failed to find the ID associated with the handle widget"
+               << handle << "with VTK ID" << handleId;
+  }
+
 }
 
 //-----------------------------------------------------------------------------

--- a/gui/GroundControlPointsHelper.cxx
+++ b/gui/GroundControlPointsHelper.cxx
@@ -466,7 +466,7 @@ id_t GroundControlPointsHelperPrivate::addGroundControlPoint()
     this->worldWidget->handleWidget(this->worldWidget->activeHandle());
 
   this->gcpHandleToIdMap[handle] = id;
-  this->gcpIdToHandleMap[this->nextId] = handle;
+  this->gcpIdToHandleMap[id] = handle;
 
   this->resetPoint(id, Reset::Silent);
 
@@ -1027,6 +1027,44 @@ std::vector<gcp_sptr> GroundControlPointsHelper::groundControlPoints() const
   }
 
   return out;
+}
+
+//-----------------------------------------------------------------------------
+kv::feature_track_set_sptr
+GroundControlPointsHelper::registrationTracks() const
+{
+  QTE_D();
+
+  auto out = std::make_shared<kv::feature_track_set>();
+
+  for (auto const& iter : d->groundControlPoints)
+  {
+    if (iter.second.feature)
+    {
+      out->insert(iter.second.feature);
+    }
+  }
+
+  return out;
+}
+
+//-----------------------------------------------------------------------------
+kv::landmark_map_sptr GroundControlPointsHelper::registrationLandmarks() const
+{
+  QTE_D();
+
+  auto landmarks = kv::landmark_map::map_landmark_t{};
+
+  for (auto const& iter : d->groundControlPoints)
+  {
+    if (iter.second.gcp)
+    {
+      auto lm = std::make_shared<kv::landmark_d>(iter.second.gcp->loc());
+      landmarks.emplace(iter.first, lm);
+    }
+  }
+
+  return std::make_shared<kv::simple_landmark_map>(landmarks);
 }
 
 //-----------------------------------------------------------------------------

--- a/gui/GroundControlPointsHelper.h
+++ b/gui/GroundControlPointsHelper.h
@@ -99,11 +99,14 @@ signals:
   void activePointChanged(id_t);
 
 protected slots:
+  void addRegistrationPoint();
   void addCameraViewPoint();
   void addWorldViewPoint();
 
-  void removePointByHandle(int handleId);
+  void removeCrpByHandle(int handleId);
+  void removeGcpByHandle(int handleId);
 
+  void moveRegistrationPoint();
   void moveCameraViewPoint();
   void moveWorldViewPoint();
 

--- a/gui/GroundControlPointsHelper.h
+++ b/gui/GroundControlPointsHelper.h
@@ -31,13 +31,13 @@
 #ifndef TELESCULPTOR_GROUNDCONTROLPOINTSHELPER_H_
 #define TELESCULPTOR_GROUNDCONTROLPOINTSHELPER_H_
 
-// maptk includes
 #include <maptk/ground_control_point.h>
 
-// qtExtensions includes
+#include <vital/types/feature_track_set.h>
+#include <vital/types/landmark_map.h>
+
 #include <qtGlobal.h>
 
-// Qt declarations
 #include <QObject>
 
 // Forward declarations
@@ -65,8 +65,14 @@ public:
   // Set ground control points
   void setGroundControlPoints(kwiver::vital::ground_control_point_map const&);
 
-  // Get access to the ground control points
+  // Get ground control points
   std::vector<gcp_sptr> groundControlPoints() const;
+
+  // Get camera registration points
+  kwiver::vital::feature_track_set_sptr registrationTracks() const;
+
+  // Get ground control points as landmarks
+  kwiver::vital::landmark_map_sptr registrationLandmarks() const;
 
   // Get access to a single ground control point
   gcp_sptr groundControlPoint(id_t pointId);

--- a/gui/GroundControlPointsView.cxx
+++ b/gui/GroundControlPointsView.cxx
@@ -416,6 +416,7 @@ void GroundControlPointsView::setHelper(GroundControlPointsHelper* helper)
             {
               d->showPoint(id);
             }
+            d->model.modifyPoint(id);
           });
   connect(helper, &GroundControlPointsHelper::pointsRecomputed,
           this, [d](){

--- a/gui/GroundControlPointsView.cxx
+++ b/gui/GroundControlPointsView.cxx
@@ -237,10 +237,15 @@ void GroundControlPointsViewPrivate::setPointPosition(id_t id)
 //-----------------------------------------------------------------------------
 id_t GroundControlPointsViewPrivate::selectedPoint() const
 {
-  auto const& i = this->UI.pointsList->selectionModel()->currentIndex();
-  auto const& ni = this->model.index(i.row(), 0, i.parent());
-  auto const& id = this->model.data(ni, Qt::EditRole);
-  return (id.isValid() ? id.value<id_t>() : INVALID_POINT);
+  auto const& s = this->UI.pointsList->selectionModel()->selectedIndexes();
+  if (!s.isEmpty())
+  {
+    auto const& i = s.first();
+    auto const& ni = this->model.index(i.row(), 0, i.parent());
+    auto const& id = this->model.data(ni, Qt::EditRole);
+    return (id.isValid() ? id.value<id_t>() : INVALID_POINT);
+  }
+  return INVALID_POINT;
 }
 
 //-----------------------------------------------------------------------------
@@ -301,7 +306,7 @@ GroundControlPointsView::GroundControlPointsView(
   d->UI.pointsList->setContextMenuPolicy(Qt::CustomContextMenu);
 
   connect(d->UI.pointsList->selectionModel(),
-          &QItemSelectionModel::currentChanged,
+          &QItemSelectionModel::selectionChanged,
           this, [d]{
             auto const id = d->selectedPoint();
 

--- a/gui/GroundControlPointsWidget.cxx
+++ b/gui/GroundControlPointsWidget.cxx
@@ -87,12 +87,10 @@ GroundControlPointsWidgetPrivate::GroundControlPointsWidgetPrivate()
   this->widget->ManagesCursorOn();
   this->repr->SetHandleRepresentation(this->pointRepr.GetPointer());
   vtkNew<vtkProperty> property;
-  property->SetColor(1, 1, 1);
   property->SetLineWidth(1.0);
   property->SetRenderLinesAsTubes(false);
   this->pointRepr->SetProperty(property.GetPointer());
   vtkNew<vtkProperty> selectedProperty;
-  selectedProperty->SetColor(0, 1, 0);
   selectedProperty->SetLineWidth(3.0);
   selectedProperty->SetRenderLinesAsTubes(true);
   this->pointRepr->SetSelectedProperty(selectedProperty.GetPointer());
@@ -135,6 +133,9 @@ GroundControlPointsWidget::GroundControlPointsWidget(QObject* parent)
   , d_ptr(new GroundControlPointsWidgetPrivate)
 {
   QTE_D();
+
+  this->setColor(Qt::white);
+  this->setSelectedColor(Qt::green);
 
   d->connections->Connect(d->widget.GetPointer(),
                           vtkCommand::PlacePointEvent,
@@ -189,6 +190,24 @@ void GroundControlPointsWidget::setPointPlacer(vtkPointPlacer* placer)
 {
   QTE_D();
   d->pointRepr->SetPointPlacer(placer);
+}
+
+//-----------------------------------------------------------------------------
+void GroundControlPointsWidget::setColor(QColor color)
+{
+  QTE_D();
+
+  auto* const property = d->pointRepr->GetProperty();
+  property->SetColor(color.redF(), color.greenF(), color.blueF());
+}
+
+//-----------------------------------------------------------------------------
+void GroundControlPointsWidget::setSelectedColor(QColor color)
+{
+  QTE_D();
+
+  auto* const property = d->pointRepr->GetSelectedProperty();
+  property->SetColor(color.redF(), color.greenF(), color.blueF());
 }
 
 //-----------------------------------------------------------------------------

--- a/gui/GroundControlPointsWidget.cxx
+++ b/gui/GroundControlPointsWidget.cxx
@@ -51,6 +51,7 @@
 
 // Qt includes
 #include <QApplication>
+#include <QSignalBlocker>
 
 QTE_IMPLEMENT_D_FUNC(GroundControlPointsWidget)
 
@@ -167,8 +168,12 @@ GroundControlPointsWidget::~GroundControlPointsWidget()
 void GroundControlPointsWidget::enableWidget(bool enable)
 {
   QTE_D();
-  d->widget->SetEnabled(enable);
-  d->widget->GetInteractor()->Render();
+
+  with_expr (QSignalBlocker{this})
+  {
+    d->widget->SetEnabled(enable);
+    d->widget->GetInteractor()->Render();
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/gui/GroundControlPointsWidget.cxx
+++ b/gui/GroundControlPointsWidget.cxx
@@ -454,6 +454,11 @@ void GroundControlPointsWidget::setActivePoint(int id)
 {
   QTE_D();
 
+  if (!d->repr->GetNumberOfSeeds())
+  {
+    return;
+  }
+
   if (d->repr->GetActiveHandle() == id)
   {
     return;

--- a/gui/GroundControlPointsWidget.h
+++ b/gui/GroundControlPointsWidget.h
@@ -31,16 +31,13 @@
 #ifndef TELESCULPTOR_GROUNDCONTROLPOINTSWIDGET_H_
 #define TELESCULPTOR_GROUNDCONTROLPOINTSWIDGET_H_
 
-// qtExtensions includes
-#include <qtGlobal.h>
-
-// kwiver includes
 #include <vital/types/vector.h>
 
-// Qt includes
+#include <qtGlobal.h>
+
+#include <QColor>
 #include <QObject>
 
-// STL includes
 #include <list>
 
 // Forward declarations
@@ -111,6 +108,9 @@ signals:
   void activePointChanged(int id);
 
 public slots:
+  void setColor(QColor);
+  void setSelectedColor(QColor);
+
   /// Delete the point and remove the widget handle
   void deletePoint(int handleId);
   // Set active handle

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1622,9 +1622,11 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
           this, [d](size_t count) {
             d->UI.actionExportGroundControlPoints->setEnabled(count > 0);
           });
-  connect(d->UI.worldView, &WorldView::pointPlacementEnabled,
-          d->groundControlPointsHelper,
-          &GroundControlPointsHelper::enableWidgets);
+  connect(d->UI.worldView, &WorldView::pointPlacementEnabled, this,
+          [d](bool state) {
+            d->UI.cameraView->setRegistrationPointEditingEnabled(!state);
+            d->groundControlPointsHelper->enableWidgets(state);
+          });
   d->UI.groundControlPoints->setHelper(d->groundControlPointsHelper);
 
   // Ruler widget

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1009,7 +1009,7 @@ void MainWindowPrivate::updateCameraView()
   if (this->activeCameraIndex < 1)
   {
     this->loadEmptyImage(nullptr);
-    this->UI.cameraView->setActiveFrame(static_cast<unsigned>(-1));
+    this->UI.cameraView->setActiveFrame(-1);
     this->UI.cameraView->clearLandmarks();
     this->UI.cameraView->clearGroundControlPoints();
     return;
@@ -2743,14 +2743,22 @@ void MainWindow::nextSlide()
 }
 
 //-----------------------------------------------------------------------------
-void MainWindow::setActiveFrame(kwiver::vital::frame_id_t id)
+kv::frame_id_t MainWindow::activeFrame() const
+{
+  QTE_D();
+
+  return d->activeCameraIndex;
+}
+
+//-----------------------------------------------------------------------------
+void MainWindow::setActiveFrame(kv::frame_id_t id)
 {
   QTE_D();
 
   auto const lastFrameId = d->frames.isEmpty() ? 0 : d->frames.lastKey();
   if (id < 1 || id > lastFrameId)
   {
-    qDebug() << "MainWindow::setActiveCamera:"
+    qDebug() << "MainWindow::setActiveFrame:"
              << " requested ID" << id << "is invalid";
     return;
   }
@@ -3394,7 +3402,7 @@ void MainWindow::updateToolProgress(QString const& desc, int progress)
 }
 
 //-----------------------------------------------------------------------------
-WorldView* MainWindow::worldView()
+WorldView* MainWindow::worldView() const
 {
   QTE_D();
 
@@ -3402,7 +3410,7 @@ WorldView* MainWindow::worldView()
 }
 
 //-----------------------------------------------------------------------------
-CameraView* MainWindow::cameraView()
+CameraView* MainWindow::cameraView() const
 {
   QTE_D();
 
@@ -3418,7 +3426,7 @@ kwiver::vital::local_geo_cs MainWindow::localGeoCoordinateSystem() const
 }
 
 //-----------------------------------------------------------------------------
-kwiver::arrows::vtk::vtkKwiverCamera* MainWindow::activeCamera()
+kwiver::arrows::vtk::vtkKwiverCamera* MainWindow::activeCamera() const
 {
   QTE_D();
 
@@ -3427,7 +3435,7 @@ kwiver::arrows::vtk::vtkKwiverCamera* MainWindow::activeCamera()
     return nullptr;
   }
 
-  auto* const activeFrame = qtGet(qAsConst(d->frames), d->activeCameraIndex);
+  auto* const activeFrame = qtGet(d->frames, d->activeCameraIndex);
   return (activeFrame ? activeFrame->camera : nullptr);
 }
 

--- a/gui/MainWindow.h
+++ b/gui/MainWindow.h
@@ -59,10 +59,11 @@ public:
   explicit MainWindow(QWidget* parent = nullptr, Qt::WindowFlags flags = {});
   ~MainWindow() override;
 
-  kwiver::arrows::vtk::vtkKwiverCamera* activeCamera();
+  kwiver::vital::frame_id_t activeFrame() const;
+  kwiver::arrows::vtk::vtkKwiverCamera* activeCamera() const;
 
-  WorldView* worldView();
-  CameraView* cameraView();
+  WorldView* worldView() const;
+  CameraView* cameraView() const;
 
   kwiver::vital::local_geo_cs localGeoCoordinateSystem() const;
 

--- a/gui/MainWindow.h
+++ b/gui/MainWindow.h
@@ -106,6 +106,7 @@ public slots:
   void acceptToolSaveResults(std::shared_ptr<ToolData> data);
 
   void applySimilarityTransform();
+  void computeCamera();
 
   void saveWebGLScene();
 

--- a/gui/WorldView.ui
+++ b/gui/WorldView.ui
@@ -28,19 +28,17 @@
    </property>
    <item>
     <widget class="QToolBar" name="toolBar">
-     <property name="toolButtonStyle">
-      <enum>Qt::ToolButtonFollowStyle</enum>
-     </property>
      <addaction name="actionViewReset"/>
      <addaction name="separator"/>
      <addaction name="actionShowFrameImage"/>
      <addaction name="actionShowCameras"/>
      <addaction name="actionShowLandmarks"/>
-     <addaction name="actionPlaceEditGCP"/>
      <addaction name="actionShowGroundPlane"/>
      <addaction name="actionSelectROI"/>
      <addaction name="actionShowDepthMap"/>
      <addaction name="actionShowVolume"/>
+     <addaction name="separator"/>
+     <addaction name="actionPlaceEditGCP"/>
      <addaction name="actionShowRuler"/>
     </widget>
    </item>

--- a/gui/vtkMaptkSeedWidget.cxx
+++ b/gui/vtkMaptkSeedWidget.cxx
@@ -240,23 +240,17 @@ void vtkMaptkSeedWidget::HighlightActiveSeed()
   int activeHandle = rep->GetActiveHandle();
   if (activeHandle < 0 || activeHandle >= rep->GetNumberOfSeeds())
   {
-    activeHandle = rep->GetNumberOfSeeds() - 1;
+    activeHandle = -1;
   }
 
   vtkSeedListIterator iter = this->Seeds->begin();
   for (int n = 0; iter != this->Seeds->end(); ++n, ++iter)
   {
-    if (this->GetEnabled() && n == activeHandle)
-    {
-      (*iter)->GetHandleRepresentation()->Highlight(1);
-      this->InvokeEvent(vtkMaptkSeedWidget::ActiveSeedChangedEvent,
-                        &activeHandle);
-    }
-    else
-    {
-      (*iter)->GetHandleRepresentation()->Highlight(0);
-    }
+    (*iter)->GetHandleRepresentation()->Highlight(
+      this->GetEnabled() && n == activeHandle);
   }
+  this->InvokeEvent(vtkMaptkSeedWidget::ActiveSeedChangedEvent,
+                    &activeHandle);
   this->Render();
 }
 


### PR DESCRIPTION
This adds ability to create "camera registration points" to TeleSculptor, and to use the same in combination with ground control points to compute a camera.

Note that, in order to be usable, this depends on having an implementation of the `resection_camera` algorithm, which as of writing, there is no implementation available in kwiver/master. This also probably still needs for the superbuild's kwiver version to be updated.

This should also probably get a release note.