### PR TITLE
Ensure export cameras is enabled

### DIFF
--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -3436,6 +3436,7 @@ void MainWindow::computeCamera()
     if (camera)
     {
       d->updateCamera(d->activeCameraIndex, camera);
+      d->UI.actionExportCameras->setEnabled(true);
     }
   }
   catch (std::exception const& e)


### PR DESCRIPTION
Enable action to export cameras after a camera is computed. This ensures that newly computed cameras can be exported if there were no cameras previously.