### PR TITLE
Manage cameras ad-hoc, not in batch

### DIFF
--- a/CMake/telesculptor-external-kwiver.cmake
+++ b/CMake/telesculptor-external-kwiver.cmake
@@ -18,7 +18,7 @@ ExternalProject_Add(kwiver
   BINARY_DIR ${TELESCULPTOR_EXTERNAL_DIR}/kwiver-build
   STAMP_DIR ${TELESCULPTOR_STAMP_DIR}
   GIT_REPOSITORY "https://github.com/Kitware/kwiver.git"
-  GIT_TAG 053f5aaa9962caf3e536fba34fcc4e5dd44b709e
+  GIT_TAG 68709c321bd23cf541b9b3acbf8ef728754df5bc
   #GIT_SHALLOW 1
   CMAKE_CACHE_ARGS
     -DBUILD_SHARED_LIBS:BOOL=ON

--- a/gui/ColorizeSurfaceOptions.cxx
+++ b/gui/ColorizeSurfaceOptions.cxx
@@ -48,30 +48,30 @@
 
 #include <QDebug>
 
+namespace kv = kwiver::vital;
+
 //-----------------------------------------------------------------------------
 class ColorizeSurfaceOptionsPrivate
 {
 public:
-  ColorizeSurfaceOptionsPrivate(): volumeActor(nullptr), currentFrame(-1)
-  {}
-
   MainWindow* mainWindow = nullptr;
 
   Ui::ColorizeSurfaceOptions UI;
   qtUiState uiState;
 
-  vtkActor* volumeActor;
+  vtkActor* volumeActor = nullptr;
 
-  kwiver::vital::config_block_sptr videoConfig;
+  kv::config_block_sptr videoConfig;
   std::string videoPath;
-  kwiver::vital::config_block_sptr maskConfig;
+  kv::config_block_sptr maskConfig;
   std::string maskPath;
-  kwiver::vital::camera_map_sptr cameras;
+  kv::camera_map_of_sptr<kv::camera> cameras =
+    std::make_shared<kv::camera_map_of_<kv::camera>>();
 
   QString krtdFile;
   QString frameFile;
 
-  kwiver::vital::frame_id_t currentFrame;
+  kv::frame_id_t currentFrame = -1;
 };
 
 QTE_IMPLEMENT_D_FUNC(ColorizeSurfaceOptions)
@@ -163,7 +163,7 @@ int ColorizeSurfaceOptions::getFrameSampling() const
 }
 
 //-----------------------------------------------------------------------------
-void ColorizeSurfaceOptions::setCurrentFrame(kwiver::vital::frame_id_t frame)
+void ColorizeSurfaceOptions::setCurrentFrame(kv::frame_id_t frame)
 {
   QTE_D();
 
@@ -188,8 +188,8 @@ void ColorizeSurfaceOptions::setActor(vtkActor* actor)
 }
 
 //-----------------------------------------------------------------------------
-void ColorizeSurfaceOptions::setVideoConfig(std::string const& path,
-                                            kwiver::vital::config_block_sptr config)
+void ColorizeSurfaceOptions::setVideoConfig(
+  std::string const& path, kv::config_block_sptr config)
 {
   QTE_D();
 
@@ -198,7 +198,7 @@ void ColorizeSurfaceOptions::setVideoConfig(std::string const& path,
 }
 
 //-----------------------------------------------------------------------------
-kwiver::vital::config_block_sptr ColorizeSurfaceOptions::getVideoConfig() const
+kv::config_block_sptr ColorizeSurfaceOptions::getVideoConfig() const
 {
   QTE_D();
 
@@ -214,8 +214,8 @@ std::string ColorizeSurfaceOptions::getVideoPath() const
 }
 
 //-----------------------------------------------------------------------------
-void ColorizeSurfaceOptions::setMaskConfig(std::string const& path,
-                                           kwiver::vital::config_block_sptr config)
+void ColorizeSurfaceOptions::setMaskConfig(
+  std::string const& path, kv::config_block_sptr config)
 {
   QTE_D();
   d->maskConfig = config;
@@ -228,7 +228,7 @@ void ColorizeSurfaceOptions::setMaskConfig(std::string const& path,
 }
 
 //-----------------------------------------------------------------------------
-kwiver::vital::config_block_sptr ColorizeSurfaceOptions::getMaskConfig() const
+kv::config_block_sptr ColorizeSurfaceOptions::getMaskConfig() const
 {
   QTE_D();
   return d->maskConfig;
@@ -242,11 +242,19 @@ std::string ColorizeSurfaceOptions::getMaskPath() const
 }
 
 //-----------------------------------------------------------------------------
-void ColorizeSurfaceOptions::setCameras(kwiver::vital::camera_map_sptr cameras)
+void ColorizeSurfaceOptions::setCamera(
+  kv::frame_id_t id, kv::camera_sptr const& camera)
 {
   QTE_D();
 
-  d->cameras = cameras;
+  if (camera)
+  {
+    d->cameras->insert(id, camera);
+  }
+  else
+  {
+    d->cameras->erase(id);
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/gui/ColorizeSurfaceOptions.h
+++ b/gui/ColorizeSurfaceOptions.h
@@ -77,15 +77,18 @@ public:
   }
 
   void setActor(vtkActor* actor);
-  void setVideoConfig(std::string const& path, kwiver::vital::config_block_sptr config);
+  void setVideoConfig(std::string const& path,
+                      kwiver::vital::config_block_sptr config);
   kwiver::vital::config_block_sptr getVideoConfig() const;
   std::string getVideoPath() const;
 
-  void setMaskConfig(std::string const& path, kwiver::vital::config_block_sptr config);
+  void setMaskConfig(std::string const& path,
+                     kwiver::vital::config_block_sptr config);
   kwiver::vital::config_block_sptr getMaskConfig() const;
   std::string getMaskPath() const;
 
-  void setCameras(kwiver::vital::camera_map_sptr cameras);
+  void setCamera(kwiver::vital::frame_id_t id,
+                 kwiver::vital::camera_sptr const& camera);
   kwiver::vital::camera_map_sptr getCameras() const;
   void enableMenu(bool);
   void forceColorize();

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -869,7 +869,7 @@ void MainWindowPrivate::updateCameras(
 {
   auto allowExport = false;
 
-  std::set<kv::frame_id_t> updated_frame_ids;
+  auto updated_frame_ids = QSet<kv::frame_id_t>{};
   foreach (auto const& iter, cameras->cameras())
   {
     auto cam_ptr =
@@ -883,18 +883,13 @@ void MainWindowPrivate::updateCameras(
 
   for (auto& f : this->frames)
   {
-    auto fid = f.id;
-    if (updated_frame_ids.find(fid) != updated_frame_ids.end())
+    if (!updated_frame_ids.contains(f.id) && f.camera)
     {
-      continue;
-    }
-    if (f.camera)
-    {
-      f.camera = NULL;
-      this->UI.worldView->removeCamera(fid);
+      f.camera = nullptr;
+      this->UI.worldView->removeCamera(f.id);
     }
   }
-  this->UI.worldView->setCameras(cameras);
+  this->UI.worldView->invalidateCameras();
 
   this->UI.actionExportCameras->setEnabled(allowExport);
 }
@@ -917,9 +912,14 @@ bool MainWindowPrivate::updateCamera(kv::frame_id_t frame,
   if (!fr->camera)
   {
     fr->camera = vtkSmartPointer<kwiver::arrows::vtk::vtkKwiverCamera>::New();
+    fr->camera->SetCamera(cam);
     this->UI.worldView->addCamera(fr->id, fr->camera);
   }
-  fr->camera->SetCamera(cam);
+  else
+  {
+    fr->camera->SetCamera(cam);
+    this->UI.worldView->updateCamera(fr->id, fr->camera);
+  }
   fr->camera->Update();
 
   // Remove from orphanFrames if needed.
@@ -1142,7 +1142,7 @@ int MainWindowPrivate::loadCameras()
         }
       }
     }
-    this->UI.worldView->setCameras(this->cameraMap());
+    this->UI.worldView->invalidateCameras();
   }
   return num_cams_loaded_from_krtd;
 }
@@ -3487,6 +3487,7 @@ void MainWindow::computeCamera()
     {
       d->updateCamera(d->activeCameraIndex, camera);
       d->UI.actionExportCameras->setEnabled(true);
+      d->UI.worldView->invalidateCameras();
     }
   }
   catch (std::exception const& e)

--- a/gui/VolumeOptions.cxx
+++ b/gui/VolumeOptions.cxx
@@ -152,11 +152,12 @@ double VolumeOptions::getOcclusionThreshold() const
 
 
 //-----------------------------------------------------------------------------
-void VolumeOptions::setCameras(kwiver::vital::camera_map_sptr cameras)
+void VolumeOptions::setCamera(
+  kwiver::vital::frame_id_t id, kwiver::vital::camera_sptr const& camera)
 {
   QTE_D();
 
-  d->colorizeSurfaceOptions->setCameras(cameras);
+  d->colorizeSurfaceOptions->setCamera(id, camera);
 }
 
 //-----------------------------------------------------------------------------

--- a/gui/VolumeOptions.h
+++ b/gui/VolumeOptions.h
@@ -60,8 +60,10 @@ public:
   int getFrameSampling() const;
   double getOcclusionThreshold() const;
 
-  void setCameras(kwiver::vital::camera_map_sptr cameras);
+  void setCamera(kwiver::vital::frame_id_t id,
+                 kwiver::vital::camera_sptr const& camera);
   kwiver::vital::camera_map_sptr getCameras() const;
+
   void setVideoConfig(std::string const& path,
                       kwiver::vital::config_block_sptr config);
   kwiver::vital::config_block_sptr getVideoConfig() const;

--- a/gui/WorldView.cxx
+++ b/gui/WorldView.cxx
@@ -855,12 +855,11 @@ void WorldView::setMaskConfig(QString const& path,
 }
 
 //-----------------------------------------------------------------------------
-void WorldView::setCameras(kwiver::vital::camera_map_sptr cameras)
+void WorldView::invalidateCameras()
 {
   QTE_D();
 
   d->cameraRep->CamerasModified();
-  d->volumeOptions->setCameras(cameras);
 }
 
 //-----------------------------------------------------------------------------
@@ -1052,11 +1051,23 @@ void WorldView::setMesh(vtkSmartPointer<vtkPolyData> mesh)
 void WorldView::addCamera(
   kwiver::vital::frame_id_t id, kwiver::arrows::vtk::vtkKwiverCamera* camera)
 {
-  Q_UNUSED(id)
-
   QTE_D();
 
   d->cameraRep->AddCamera(id, camera);
+
+  d->volumeOptions->setCamera(id, camera->GetCamera());
+
+  d->updateCameras(this);
+  d->updateAxes(this);
+}
+
+//-----------------------------------------------------------------------------
+void WorldView::updateCamera(
+  kwiver::vital::frame_id_t id, kwiver::arrows::vtk::vtkKwiverCamera* camera)
+{
+  QTE_D();
+
+  d->volumeOptions->setCamera(id, camera->GetCamera());
 
   d->updateCameras(this);
   d->updateAxes(this);
@@ -1068,6 +1079,11 @@ void WorldView::removeCamera(kwiver::vital::frame_id_t id)
   QTE_D();
 
   d->cameraRep->RemoveCamera(id);
+
+  d->volumeOptions->setCamera(id, nullptr);
+
+  d->updateCameras(this);
+  d->updateAxes(this);
 }
 
 //-----------------------------------------------------------------------------
@@ -1709,7 +1725,7 @@ void WorldView::saveFusedMeshFrameColors(const QString &path, bool occlusion)
   loop.exec();
 }
 
-
+//-----------------------------------------------------------------------------
 void WorldView::meshColorationHandleResult(MeshColoration* coloration)
 {
   QTE_D();

--- a/gui/WorldView.h
+++ b/gui/WorldView.h
@@ -88,7 +88,6 @@ public:
                       kwiver::vital::config_block_sptr config);
   void setMaskConfig(QString const& path,
                      kwiver::vital::config_block_sptr config);
-  void setCameras(kwiver::vital::camera_map_sptr cameras);
 
   void enableAntiAliasing(bool enable);
   void setROI(vtkBox*, bool init = false);
@@ -113,6 +112,8 @@ public slots:
 
   void addCamera(kwiver::vital::frame_id_t id,
                  kwiver::arrows::vtk::vtkKwiverCamera* camera);
+  void updateCamera(kwiver::vital::frame_id_t id,
+                    kwiver::arrows::vtk::vtkKwiverCamera* camera);
   void removeCamera(kwiver::vital::frame_id_t id);
   void setLandmarks(kwiver::vital::landmark_map const&);
 
@@ -158,6 +159,7 @@ public slots:
   void meshColorationHandleResult(MeshColoration* coloration);
 
   void invalidateGeometry();
+  void invalidateCameras();
 
   void setVolumeVisible(bool);
   void setVolumeCurrentFrame(kwiver::vital::frame_id_t);

--- a/gui/tools/MeshColoration.cxx
+++ b/gui/tools/MeshColoration.cxx
@@ -30,23 +30,26 @@
 
 #include "MeshColoration.h"
 
-
+// ----------------------------------------------------------------------------
 MeshColoration::MeshColoration(
-    kwiver::vital::config_block_sptr& videoConfig,
-    std::string const& videoPath,
-    kwiver::vital::config_block_sptr& maskConfig,
-    std::string const& maskPath,
-    kwiver::vital::camera_map_sptr& cameras) : kwiver::arrows::vtk::mesh_coloration(
+  kwiver::vital::config_block_sptr const& videoConfig,
+  std::string const& videoPath,
+  kwiver::vital::config_block_sptr const& maskConfig,
+  std::string const& maskPath,
+  kwiver::vital::camera_map_sptr const& cameras)
+  : kwiver::arrows::vtk::mesh_coloration(
       videoConfig, videoPath, maskConfig, maskPath, cameras)
 {
 }
 
+// ----------------------------------------------------------------------------
 void MeshColoration::report_progress_changed(
   const std::string& message, int percentage)
 {
   emit progressChanged(QString::fromStdString(message), percentage);
 }
 
+// ----------------------------------------------------------------------------
 void MeshColoration::run()
 {
   emit resultReady(this->colorize() ? this : nullptr);

--- a/gui/tools/MeshColoration.h
+++ b/gui/tools/MeshColoration.h
@@ -34,16 +34,17 @@
 #include <QThread>
 #include <arrows/vtk/mesh_coloration.h>
 
-class MeshColoration : public QThread, public kwiver::arrows::vtk::mesh_coloration
+class MeshColoration : public QThread,
+                       public kwiver::arrows::vtk::mesh_coloration
 {
   Q_OBJECT;
 
 public:
-  MeshColoration(kwiver::vital::config_block_sptr& videoConfig,
+  MeshColoration(kwiver::vital::config_block_sptr const& videoConfig,
                  std::string const& videoPath,
-                 kwiver::vital::config_block_sptr& maskConfig,
+                 kwiver::vital::config_block_sptr const& maskConfig,
                  std::string const& maskPath,
-                 kwiver::vital::camera_map_sptr& cameras);
+                 kwiver::vital::camera_map_sptr const& cameras);
 
   MeshColoration(MeshColoration const&) = delete;
   MeshColoration& operator=(MeshColoration const&) = delete;
@@ -52,8 +53,9 @@ public:
   // adds an array of colors for each camera (frame) otherwise.
   void run() override;
 
-  void report_progress_changed(const std::string& message, int percentage) override;
-  
+  void report_progress_changed(
+    const std::string& message, int percentage) override;
+
 signals:
   void resultReady(MeshColoration* coloration);
   void progressChanged(QString, int);


### PR DESCRIPTION
Modify how we propagate camera updates to `ColorizeSurfaceOptions` to send individual changes rather than sending the entire camera map as one giant lump. Although this seems like it would be less efficient, the "newly extra" logic in `WorldView` is all of the "mark dirty and update later" form, and we would otherwise need to build up a map anyway, so really this is just deepening the call stack for inserting cameras into the map.

The benefit of this is that we can make individual updates without having to completely rebuild the camera map. Also, it means that `MainWindowPrivate::updateCamera` updates the `ColorizeSurfaceOptions` cameras rather than having to remember to do this as a separate step.

Additionally, this lets us separate maintaining the cameras in `ColorizeSurfaceOptions` and updating the `WorldView` camera representation, which means we can (efficiently!) do so when a camera is computed, thus fixing the bug that the representation was not being updated in this case.

Requires kitware/kwiver#1293.