### PR TITLE
Overhaul how point edit modes are enabled

### DIFF
--- a/gui/CameraView.cxx
+++ b/gui/CameraView.cxx
@@ -481,8 +481,7 @@ CameraView::CameraView(QWidget* parent, Qt::WindowFlags flags)
   d->registrationPointsWidget->setTransformMatrix(d->transformMatrix);
 
   connect(d->UI.actionPlaceEditCRP, &QAction::toggled,
-          d->registrationPointsWidget,
-          &GroundControlPointsWidget::enableWidget);
+          this, &CameraView::pointPlacementEnabled);
 
   connect(d->UI.actionComputeCamera, &QAction::triggered,
           this, &CameraView::cameraComputationRequested,
@@ -912,17 +911,16 @@ void CameraView::enableAntiAliasing(bool enable)
 }
 
 //-----------------------------------------------------------------------------
-void CameraView::setRegistrationPointEditingEnabled(bool state)
+void CameraView::setEditMode(EditMode mode)
 {
   QTE_D();
 
-  d->UI.actionPlaceEditCRP->setEnabled(state);
-
-  if (!state)
-  {
-    d->UI.actionPlaceEditCRP->setChecked(false);
-    d->registrationPointsWidget->enableWidget(false);
-  }
+  d->groundControlPointsWidget->enableWidget(
+    mode == EditMode::GroundControlPoints);
+  d->registrationPointsWidget->enableWidget(
+    mode == EditMode::CameraRegistrationPoints);
+  d->UI.actionPlaceEditCRP->setChecked(
+    mode == EditMode::CameraRegistrationPoints);
 }
 
 //-----------------------------------------------------------------------------

--- a/gui/CameraView.h
+++ b/gui/CameraView.h
@@ -31,6 +31,8 @@
 #ifndef TELESCULPTOR_CAMERAVIEW_H_
 #define TELESCULPTOR_CAMERAVIEW_H_
 
+#include "EditMode.h"
+
 #include <vital/vital_types.h>
 
 #include <qtGlobal.h>
@@ -63,6 +65,7 @@ public:
   void enableAntiAliasing(bool enable);
 
 signals:
+  void pointPlacementEnabled(bool);
   void cameraComputationRequested();
 
 public slots:
@@ -73,7 +76,7 @@ public slots:
 
   void setLandmarksData(kwiver::vital::landmark_map const&);
 
-  void setRegistrationPointEditingEnabled(bool);
+  void setEditMode(EditMode);
 
   void setActiveFrame(kwiver::vital::frame_id_t);
 

--- a/gui/EditMode.h
+++ b/gui/EditMode.h
@@ -1,0 +1,19 @@
+// This file is part of TeleSculptor, and is distributed under the
+// OSI-approved BSD 3-Clause License. See top-level LICENSE file or
+// https://github.com/Kitware/TeleSculptor/blob/master/LICENSE for details.
+
+#ifndef TELESCULPTOR_EDITMODE_H_
+#define TELESCULPTOR_EDITMODE_H_
+
+#include <QMetaType>
+
+enum class EditMode
+{
+  None,
+  GroundControlPoints,
+  CameraRegistrationPoints,
+};
+
+Q_DECLARE_METATYPE(EditMode)
+
+#endif

--- a/gui/GroundControlPointsHelper.cxx
+++ b/gui/GroundControlPointsHelper.cxx
@@ -1345,14 +1345,6 @@ bool GroundControlPointsHelper::writeGroundControlPoints(
 }
 
 //-----------------------------------------------------------------------------
-void GroundControlPointsHelper::enableWidgets(bool enable)
-{
-  QTE_D();
-  d->worldWidget->enableWidget(enable);
-  d->cameraWidget->enableWidget(enable);
-}
-
-//-----------------------------------------------------------------------------
 gcp_sptr GroundControlPointsHelper::groundControlPoint(id_t pointId)
 {
   QTE_D();

--- a/gui/GroundControlPointsHelper.h
+++ b/gui/GroundControlPointsHelper.h
@@ -83,8 +83,6 @@ public:
     QString const& path, QWidget* dialogParent) const;
 
 public slots:
-  void enableWidgets(bool);
-
   void recomputePoints();
 
   void resetPoint(id_t);

--- a/gui/WorldView.cxx
+++ b/gui/WorldView.cxx
@@ -1883,6 +1883,17 @@ void WorldView::updateROI(vtkObject* caller,
 }
 
 //-----------------------------------------------------------------------------
+void WorldView::setEditMode(EditMode mode)
+{
+  QTE_D();
+
+  d->groundControlPointsWidget->enableWidget(
+    mode == EditMode::GroundControlPoints);
+  d->UI.actionPlaceEditGCP->setChecked(
+    mode == EditMode::GroundControlPoints);
+}
+
+//-----------------------------------------------------------------------------
 GroundControlPointsWidget* WorldView::groundControlPointsWidget() const
 {
   QTE_D();

--- a/gui/WorldView.h
+++ b/gui/WorldView.h
@@ -31,14 +31,17 @@
 #ifndef TELESCULPTOR_WORLDVIEW_H_
 #define TELESCULPTOR_WORLDVIEW_H_
 
+#include "EditMode.h"
+
 #include <vital/config/config_block_types.h>
 #include <vital/types/camera_map.h>
 #include <vital/types/local_geo_cs.h>
 
+#include <vtkSmartPointer.h>
+
 #include <qtGlobal.h>
 
 #include <QWidget>
-#include <vtkSmartPointer.h>
 
 class vtkBox;
 class vtkImageData;
@@ -146,6 +149,7 @@ public slots:
   void viewToWorldFront();
   void viewToWorldBack();
 
+  void setEditMode(EditMode);
 
   void saveDepthPoints(QString const & path,
                        kwiver::vital::local_geo_cs const & lgcs);


### PR DESCRIPTION
Move logic to enable point editing widgets into the respective views, purging it from `GroundControlPointsHelper`. This requires adding additional API's to the views, but allows us to eliminate the need to "lock out" editing registration points to edit ground control points (which was previously needed as there was no API to tell the `CameraView` to turn editing off).