### PR TITLE
Always highlight active seed

### DIFF
--- a/gui/vtkMaptkSeedWidget.cxx
+++ b/gui/vtkMaptkSeedWidget.cxx
@@ -246,8 +246,7 @@ void vtkMaptkSeedWidget::HighlightActiveSeed()
   vtkSeedListIterator iter = this->Seeds->begin();
   for (int n = 0; iter != this->Seeds->end(); ++n, ++iter)
   {
-    (*iter)->GetHandleRepresentation()->Highlight(
-      this->GetEnabled() && n == activeHandle);
+    (*iter)->GetHandleRepresentation()->Highlight(n == activeHandle);
   }
   this->InvokeEvent(vtkMaptkSeedWidget::ActiveSeedChangedEvent,
                     &activeHandle);


### PR DESCRIPTION
Modify `vtkMaptkSeedWidget` to always highlight the active seed; not just when the widget is enabled (i.e. when we are in point editing mode).