### PR TITLE
Remember [fused] mesh

### DIFF
--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1800,8 +1800,16 @@ void MainWindow::openGroundControlPoints()
 //-----------------------------------------------------------------------------
 void MainWindow::openMesh()
 {
+  QTE_D();
+
+  auto initialDir = QString{};
+  if (d->project && !d->project->meshPath.isEmpty())
+  {
+    initialDir = QFileInfo{d->project->meshPath}.absolutePath();
+  }
+
   auto const path = QFileDialog::getOpenFileName(
-    this, "Open Mesh File", QString(),
+    this, "Open Mesh File", initialDir,
     "PLY Files (*.ply);;"
     "All Files (*)");
 

--- a/gui/Project.cxx
+++ b/gui/Project.cxx
@@ -138,6 +138,12 @@ bool Project::read(QString const& path)
       this->volumePath = getPath(this, "volume_file");
     }
 
+    // Read Mesh file
+    if (this->config->has_value("mesh_file"))
+    {
+      this->meshPath = getPath(this, "mesh_file");
+    }
+
     // Read the geo origin file
     if (this->config->has_value("geo_origin_file"))
     {

--- a/gui/Project.h
+++ b/gui/Project.h
@@ -65,6 +65,7 @@ public:
   QString cameraPath;
   QString geoOriginFile;
   QString depthPath;
+  QString meshPath;
   QString groundControlPath;
   QString logFilePath;
 

--- a/gui/WorldView.cxx
+++ b/gui/WorldView.cxx
@@ -1017,7 +1017,6 @@ bool WorldView::loadMesh(QString const& path)
   vtkNew<vtkPLYReader> reader;
   reader->SetFileName(qPrintable(path));
   reader->Update();
-  
   QGuiApplication::restoreOverrideCursor();
 
   auto mesh = vtkPolyData::SafeDownCast(reader->GetOutput());

--- a/gui/WorldView.h
+++ b/gui/WorldView.h
@@ -74,13 +74,13 @@ public:
 
   void initFrameSampling(int nbFrames);
 
-  void loadVolume(QString const& path);
+  bool loadVolume(QString const& path);
 
   void setVolume(vtkSmartPointer<vtkImageData> volume);
 
   void resetVolume();
 
-  void loadMesh(QString const& path);
+  bool loadMesh(QString const& path);
 
   void setMesh(vtkSmartPointer<vtkPolyData> mesh);
 
@@ -147,12 +147,12 @@ public slots:
   void viewToWorldBack();
 
 
-  void saveDepthPoints(QString const & path,
+  bool saveDepthPoints(QString const & path,
                        kwiver::vital::local_geo_cs const & lgcs);
   void exportWebGLScene(QString const& path);
 
-  void saveVolume(QString const& path);
-  void saveFusedMesh(QString const& path,
+  bool saveVolume(QString const& path);
+  bool saveFusedMesh(QString const& path,
                      kwiver::vital::local_geo_cs const & lgcs);
   void saveFusedMeshFrameColors(QString const& path, bool occlusion = true);
   void meshColorationHandleResult(MeshColoration* coloration);


### PR DESCRIPTION
Remember the [fused] mesh in the project when one is loaded or saved. Also, modify a bunch of methods in `WorldView` to return success/failure rather than nothing, which we can use to determine when we should write changes to the project.