### PR TITLE
Add icon to points with CRP on current frame

### DIFF
--- a/gui/GroundControlPointsHelper.cxx
+++ b/gui/GroundControlPointsHelper.cxx
@@ -1351,3 +1351,11 @@ gcp_sptr GroundControlPointsHelper::groundControlPoint(id_t pointId)
   auto it = d->groundControlPoints.find(pointId);
   return it == d->groundControlPoints.end() ? nullptr : it->second.gcp;
 }
+
+//-----------------------------------------------------------------------------
+kv::track_sptr GroundControlPointsHelper::registrationTrack(id_t pointId)
+{
+  QTE_D();
+  auto it = d->groundControlPoints.find(pointId);
+  return it == d->groundControlPoints.end() ? nullptr : it->second.feature;
+}

--- a/gui/GroundControlPointsHelper.h
+++ b/gui/GroundControlPointsHelper.h
@@ -50,6 +50,7 @@ class GroundControlPointsHelper : public QObject
 public:
   using id_t = kwiver::vital::ground_control_point_id_t;
   using gcp_sptr = kwiver::vital::ground_control_point_sptr;
+  using crt_sptr = kwiver::vital::track_sptr;
 
   GroundControlPointsHelper(QObject* parent = nullptr);
   ~GroundControlPointsHelper();
@@ -76,6 +77,9 @@ public:
 
   // Get access to a single ground control point
   gcp_sptr groundControlPoint(id_t pointId);
+
+  // Get access to a camera registration "track"
+  crt_sptr registrationTrack(id_t pointId);
 
   bool readGroundControlPoints(QString const& path);
 

--- a/gui/GroundControlPointsModel.h
+++ b/gui/GroundControlPointsModel.h
@@ -33,6 +33,8 @@
 
 #include <maptk/ground_control_point.h>
 
+#include <vital/vital_types.h>
+
 #include <qtGlobal.h>
 
 #include <QAbstractItemModel>
@@ -71,6 +73,7 @@ public:
   void setDataSource(GroundControlPointsHelper*);
 
   void setRegisteredIcon(QIcon const& icon);
+  void setSurveyedIcon(QIcon const& icon);
 
 public slots:
   void addPoint(kwiver::vital::ground_control_point_id_t);
@@ -78,6 +81,8 @@ public slots:
   void modifyPoint(kwiver::vital::ground_control_point_id_t);
 
   void resetPoints();
+
+  void setActiveCamera(kwiver::vital::frame_id_t);
 
 private:
   QTE_DECLARE_PRIVATE_RPTR(GroundControlPointsModel)

--- a/gui/GroundControlPointsView.h
+++ b/gui/GroundControlPointsView.h
@@ -50,6 +50,9 @@ public:
 
   void setHelper(GroundControlPointsHelper*);
 
+public slots:
+  void setActiveCamera(qint64 id);
+
 protected:
   void changeEvent(QEvent* e) override;
   void showEvent(QShowEvent* e) override;

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1033,6 +1033,7 @@ void MainWindowPrivate::setActiveCamera(kv::frame_id_t id)
 
   this->activeCameraIndex = id;
   this->UI.worldView->setActiveCamera(id);
+  this->UI.groundControlPoints->setActiveCamera(id);
 
   this->updateCameraView();
 

--- a/gui/icons/icons.qrc
+++ b/gui/icons/icons.qrc
@@ -123,5 +123,6 @@
   </qresource>
   <qresource prefix="icons/scalable">
     <file alias="registered">scalable/registered.svg</file>
+    <file alias="surveyed">scalable/surveyed.svg</file>
   </qresource>
 </RCC>

--- a/gui/icons/scalable/registered.svg
+++ b/gui/icons/scalable/registered.svg
@@ -1,104 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
    width="16"
    height="16"
-   viewBox="0 0 16 16"
-   version="1.1"
-   id="svg8"
-   inkscape:version="0.92.4 (unknown)"
-   sodipodi:docname="registered.svg">
-  <defs
-     id="defs2" />
+   viewBox="0 0 16 16">
   <sodipodi:namedview
-     id="base"
-     pagecolor="#000000"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="32"
-     inkscape:cx="8"
-     inkscape:cy="8"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     units="px"
-     inkscape:snap-center="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1174"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1">
-    <inkscape:grid
-       type="xygrid"
-       id="grid815"
-       empspacing="4" />
-  </sodipodi:namedview>
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+     pagecolor="#000000" />
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-292.76667)">
-    <circle
-       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
-       id="circle4500"
-       cx="7.4999995"
-       cy="297.26666"
-       r="1.09375" />
+     id="group">
     <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path5859"
-       d="m 7.5,296.26667 v -3"
-       style="fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    <path
-       sodipodi:open="true"
-       d="m 11.742641,301.5093 a 6,6 0 0 1 -6.7783504,1.19521"
-       sodipodi:end="2.0071286"
-       sodipodi:start="0.78539816"
-       sodipodi:ry="6"
-       sodipodi:rx="6"
-       sodipodi:cy="297.26666"
+       sodipodi:arc-type="arc"
        sodipodi:cx="7.5"
+       sodipodi:cy="8.5"
+       sodipodi:end="5.969026"
+       sodipodi:open="true"
+       sodipodi:rx="5.5"
+       sodipodi:ry="5.5"
+       sodipodi:start="5.0265482"
        sodipodi:type="arc"
-       id="path5861"
-       style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+       style="fill:none;stroke:#ffffff;stroke-width:1"
+       d="M 9.1995932,3.2691815 A 5.5,5.5 0 0 1 12.730811,6.8003987" />
     <path
-       inkscape:transform-center-y="5.3973219"
-       inkscape:transform-center-x="2.4068845"
-       sodipodi:nodetypes="ccccc"
-       inkscape:connector-curvature="0"
-       id="path5863"
-       d="M 7.190983,298.21773 5.4913895,303.44854 2.995248,307.8948 6.394435,297.43318 Z"
-       style="fill:#ffffff;stroke:#ffffff;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
-    <path
-       inkscape:transform-center-y="5.3973219"
-       inkscape:transform-center-x="-2.4068845"
-       style="fill:#ffffff;stroke:#ffffff;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
-       d="m 7.809017,298.21773 1.6995935,5.23081 2.4961415,4.44626 -3.399187,-10.46162 z"
-       id="path5865"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       style="fill:none;stroke:#ffffff;stroke-width:1px"
+       d="M 7.5,7 V 1.5" />
   </g>
+  <use
+     xlink:href="#group"
+     transform="rotate(-90,7.5,8.5)" />
+  <use
+     xlink:href="#group"
+     transform="rotate(180,7.5,8.5)" />
+  <use
+     xlink:href="#group"
+     transform="rotate(90,7.5,8.5)" />
 </svg>

--- a/gui/icons/scalable/surveyed.svg
+++ b/gui/icons/scalable/surveyed.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16">
+  <sodipodi:namedview
+     pagecolor="#000000" />
+  <circle
+     style="fill:none;stroke:#ffffff;stroke-width:1"
+     cx="7.5"
+     cy="4.5"
+     r="1.09375" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:1px"
+     d="m 7.5,3.5 v -3" />
+  <path
+     sodipodi:arc-type="arc"
+     sodipodi:cx="7.5"
+     sodipodi:cy="4.5"
+     sodipodi:end="2.0071286"
+     sodipodi:open="true"
+     sodipodi:rx="6"
+     sodipodi:ry="6"
+     sodipodi:start="0.78539816"
+     sodipodi:type="arc"
+     style="fill:none;stroke:#ffffff;stroke-width:1"
+     d="M 11.742641,8.742633 A 6,6 0 0 1 4.9642906,9.9378392" />
+  <path
+     style="fill:#ffffff;stroke:#ffffff;stroke-width:0.2"
+     d="m 7.5,5.5 0,5.5 -1,5 0,-11 z"
+     transform="rotate(18,7.5,4.5)" />
+  <path
+     style="fill:#ffffff;stroke:#ffffff;stroke-width:0.2"
+     d="m 7.5,5.5 0,5.5 1,5 0,-11 z"
+     transform="rotate(-18,7.5,4.5)" />
+</svg>


### PR DESCRIPTION
Modify `GroundControlPointsModel` to provide an icon on points which have a camera registration point on the active frame. Modify various bits to update the icons and active frame as needed. Simplify SVG for points that have been georegistered.

Closes #453.