### PR TITLE
Don't enable GCP editing with no camera

### DIFF
--- a/gui/CameraView.h
+++ b/gui/CameraView.h
@@ -41,8 +41,26 @@
 
 class vtkImageData;
 
-namespace kwiver { namespace vital { class landmark_map; } }
-namespace kwiver { namespace vital { class track; } }
+namespace kwiver {
+
+namespace arrows {
+
+namespace vtk {
+
+class vtkKwiverCamera;
+
+} // namespace vtk
+
+} // namespace arrows
+
+namespace vital {
+
+class landmark_map;
+class track;
+
+} // namespace vital
+
+} // namespace kwiver
 
 class GroundControlPointsWidget;
 class RulerWidget;
@@ -78,6 +96,7 @@ public slots:
 
   void setEditMode(EditMode);
 
+  void setActiveCamera(kwiver::arrows::vtk::vtkKwiverCamera*);
   void setActiveFrame(kwiver::vital::frame_id_t);
 
   void addLandmark(kwiver::vital::landmark_id_t id, double x, double y);

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1064,6 +1064,7 @@ void MainWindowPrivate::updateCameraView()
   if (this->activeCameraIndex < 1)
   {
     this->loadEmptyImage(nullptr);
+    this->UI.cameraView->setActiveCamera(nullptr);
     this->UI.cameraView->setActiveFrame(-1);
     this->UI.cameraView->clearLandmarks();
     this->UI.cameraView->clearGroundControlPoints();
@@ -1078,12 +1079,14 @@ void MainWindowPrivate::updateCameraView()
   if (!activeFrame)
   {
     this->loadEmptyImage(nullptr);
+    this->UI.cameraView->setActiveCamera(nullptr);
     this->UI.cameraView->clearLandmarks();
     return;
   }
 
   // Show camera image
   this->loadImage(*activeFrame);
+  this->UI.cameraView->setActiveCamera(activeFrame->camera);
 
   if (!activeFrame->camera)
   {


### PR DESCRIPTION
Tweak CameraView to be aware of whether or not there is a valid camera, and don't allow editing ground control points with no camera. (Note that this does not affect editing registration points.)

Fixes #470.