### PR TITLE
Avoid use of non-ASCII whitespace on Windows

### DIFF
--- a/gui/GroundControlPointsModel.cxx
+++ b/gui/GroundControlPointsModel.cxx
@@ -41,6 +41,16 @@
 
 #include <limits>
 
+// Define the string used to add a "fake" right margin to top-level items
+#ifdef Q_OS_LINUX
+// EM SPACE looks better and should be available on Linux
+#define MARGIN_SPACE u"\u2003"
+#else
+// Windows Unicode font support is trash (and apparently Q_OS_WIN is not being
+// reliably defined, so all of not-Linux loses)
+#define MARGIN_SPACE "  "
+#endif
+
 namespace kv = kwiver::vital;
 
 namespace
@@ -260,12 +270,12 @@ QVariant GroundControlPointsModel::data(
         case Qt::DisplayRole:
           if (!item.gcp)
           {
-            static const auto t = QStringLiteral("(%1)\u2003");
+            static const auto t = QStringLiteral("(%1) " MARGIN_SPACE );
             return t.arg(item.id);
           }
           else
           {
-            static const auto t = QStringLiteral("%1\u2007\u2003");
+            static const auto t = QStringLiteral("%1 " MARGIN_SPACE );
             return t.arg(item.id);
           }
 


### PR DESCRIPTION
Replace use of em-space for faking a right margin with (on Windows) two regular spaces, as apparently Windows' Unicode coverage is so lame as to lack even this basic non-ASCII character. Also, use a regular space instead of a figure space to try to line up the numbers with and without parentheses. Neither is perfect, but regular space actually seems to be slightly less 'off'.

Fixes #477.