### PR TITLE
Fix highlighting of selected point

### DIFF
--- a/gui/GroundControlPointsModel.cxx
+++ b/gui/GroundControlPointsModel.cxx
@@ -141,7 +141,7 @@ id_t GroundControlPointsModel::id(QModelIndex const& index) const
   QTE_D();
 
   auto const r = rowForIndex(index);
-  if (r < 0 || r > this->rowCount(index.parent()))
+  if (r < 0 || r > d->points.count())
   {
     return std::numeric_limits<id_t>::max();
   }

--- a/gui/GroundControlPointsView.cxx
+++ b/gui/GroundControlPointsView.cxx
@@ -250,10 +250,7 @@ id_t GroundControlPointsViewPrivate::selectedPoint() const
   auto const& s = this->UI.pointsList->selectionModel()->selectedIndexes();
   if (!s.isEmpty())
   {
-    auto const& i = s.first();
-    auto const& ni = this->model.index(i.row(), 0, i.parent());
-    auto const& id = this->model.data(ni, Qt::EditRole);
-    return (id.isValid() ? id.value<id_t>() : INVALID_POINT);
+    return this->model.id(s.first());
   }
   return INVALID_POINT;
 }


### PR DESCRIPTION
Replace "duplicated" (and wrong, at least since introducing registration points as child items) logic in `GroundControlPointsView` to get the id of a point from its model index and instead use the helper function from the model (which is correctly implemented) to do so.

Fixes #478.