### PR TITLE
Update manual

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1,0 +1,18 @@
+pre.wrap {
+  white-space: pre-wrap !important;
+}
+
+pre.literal-block,
+.filepath
+{
+  font-size: 75%;
+  font-family: monospace;
+  background: #f8f8f8;
+  color: #333;
+}
+
+.filepath {
+  white-space: pre-wrap;
+  border: 1px solid #e1e4e5;
+  padding: 2px 5px;
+}

--- a/doc/advancedconfig.rst
+++ b/doc/advancedconfig.rst
@@ -2,65 +2,107 @@
 
 .. include:: version.rst
 
-================================
+==============================
 Advanced Configuration Options
-================================
-
-Most users should not need these advanced features, but some may be interested.
-
-Changing Frame Sampling Rate
 ==============================
 
-By default, all video frames are loaded when opening a video (though not all are processed in feature tracking).  If the number of frames is too large to manage it is possible to
-read only every Nth frame by changing a setting in the project configuration.  First close the application.  Next open the project .conf file in a text editor like Notepad.  Look for
-the following line:
+Most users should not need these advanced features,
+but some may be interested.
 
-**video_reader:filter:output_nth_frame= 1**
+Changing Frame Sampling Rate
+============================
 
-Increase the number from 1 to 10 to sample every 10th frame, for example.  Save the .conf file in the text editor and open that file again in the TeleSculptor application.
+By default, all video frames are loaded when opening a video
+(though not all are processed in feature tracking).
+If the number of frames is too large to manage
+it is possible to read only every Nth frame
+by changing a setting in the project configuration.
+First, close the application.
+Next, open the project :path:`.conf` file in a text editor like Notepad.
+Look for the following line:
+
+.. code-block:: bash
+
+  video_reader:filter:output_nth_frame=1
+
+Increase the number from 1 to 10 to sample every tenth frame, for example.
+Save the :path:`.conf` file in the text editor
+and open that file again in the TeleSculptor application.
 
 Modifying Algorithm Parameters
-================================
+==============================
 
-TeleSculptor is a highly configurable application, though most of the configuration options are not yet exposed to the user interface.  Each tool in the compute menu calls an
-algorithm from the KWIVER toolkit and each algorithm is configurable at run time.  Algorithms can even be swapped out for other algorithms at run time.  One can contribute a new
-algorithm without recompiling TeleSculptor by dropping in a new DLL and updating the configuration files.  All this configurability is managed with configuration files.  The project
-file is one example of configuration file, but there are also many default configuration files loaded by TeleSculptor at run time.  The default configuration files for a standard
-install path are found in these two locations:
+TeleSculptor is a highly configurable application,
+though most of the configuration options
+are not yet exposed to the user interface.
+Each tool in the compute menu calls an algorithm from the KWIVER toolkit
+and each algorithm is configurable at run time.
+Algorithms can even be swapped out for other algorithms at run time.
+One can contribute a new algorithm without recompiling TeleSculptor
+by dropping in a new :path:`.dll` and updating the configuration files.
+All this configurability is managed with configuration files.
+The project file is one example of configuration file,
+but there are also many default configuration files
+loaded by TeleSculptor at run time.
+The default configuration files for a standard install path
+are found in these two locations:
 
-**C:\\Program Files\\TeleSculptor** |space| |version| **\\share\\telesculptor\\** |version| **\\config**
+.. parsed-literal::
+  :class: wrap
 
-**C:\\Program Files\\TeleSculptor** |space| |version| **\\share\\kwiver\\1.5.0\\config**
+  C: |backslash| Program Files |backslash| TeleSculptor |version|
+  |backslash| share |backslash| telesculptor |backslash| |version|
+  |backslash| config
 
-TeleSculptor specific configurations are found in the first directory and these include configurations for KWIVER algorithms found in the second directory.  It is recommended that
-you not modify these values, but instead copy some of these files into your project directory and modify the copies.  TeleSculptor will load configuration files from the project
-directory first.  Each of the tools in the *Compute* menu loads a configuration file when it is run.  These have names starting with a "gui\_” prefix.  For example:
+.. parsed-literal::
+  :class: wrap
 
+  C: |backslash| Program Files |backslash| TeleSculptor |version|
+  |backslash| share |backslash| kwiver |backslash| |kwiver_version|
+  |backslash| config
+
+TeleSculptor specific configurations are found in the first directory
+and these include configurations for KWIVER algorithms
+found in the second directory.
+It is recommended that you not modify these values,
+but instead copy some of these files into your project directory
+and modify the copies.
+TeleSculptor will load configuration files from the project directory first.
+Each of the tools in the *Compute* menu
+loads a configuration file when it is run.
+These have names starting with a :path:`gui\_` prefix.
+For example:
 
 .. table::
    :align: center
 
-   +---------------------------+----------------------------------+
-   | Compute Menu Name         | Configuration File Entry Point   |
-   +===========================+==================================+
-   | Track Features            | gui_track_features.conf          |
-   +---------------------------+----------------------------------+
-   | Estimate Camera/Landmarks | gui_initialize.conf              |
-   +---------------------------+----------------------------------+
-   | Save Frames               | gui_frame_image_writer.conf      |
-   +---------------------------+----------------------------------+
-   | Batch Compute Depth Maps  | gui_compute_depth.conf           |
-   +---------------------------+----------------------------------+
-   | Fuse Depth Maps           | gui_integrate_depth_maps.conf    |
-   +---------------------------+----------------------------------+
+   +---------------------------+---------------------------------------+
+   | Compute Menu Name         | Configuration File Entry Point        |
+   +===========================+=======================================+
+   | Track Features            | :path:`gui_track_features.conf`       |
+   +---------------------------+---------------------------------------+
+   | Estimate Camera/Landmarks | :path:`gui_initialize.conf`           |
+   +---------------------------+---------------------------------------+
+   | Save Frames               | :path:`gui_frame_image_writer.conf`   |
+   +---------------------------+---------------------------------------+
+   | Batch Compute Depth Maps  | :path:`gui_compute_depth.conf`        |
+   +---------------------------+---------------------------------------+
+   | Fuse Depth Maps           | :path:`gui_integrate_depth_maps.conf` |
+   +---------------------------+---------------------------------------+
 
+Most of these configuration files also
+reference other configuration files with an ``include`` statement.
+Configuration values for tools can also be added to the project file
+but copying the GUI configuration files into the project directory
+adds more flexibility because these files
+are reloaded each time the tool is run,
+which allows changing parameters between runs
+without loading the project.
 
-Most of these configuration files also reference other configuration files with an “include” statement.  Configuration values for tools can also be added to the project file but
-copying the GUI configuration files into the project directory adds more flexibility because these files are reloaded each time the tool is run, which allows changing parameters
-between runs without loading the project.
-
-As an example, consider changing the maximum number of frames to use in the feature tracker.  First copy **gui_track_features.conf** into your project directory.  Open this file and
-look for the following section:
+As an example, consider
+changing the maximum number of frames to use in the feature tracker.
+First, copy :path:`gui_track_features.conf` into your project directory.
+Open this file and look for the following section:
 
 .. code-block:: bash
 
@@ -74,26 +116,52 @@ look for the following section:
    endblock
 
 
-Modify the line with “max_frame = 500” use a different value, such as 1000.  Note that you could also make this change in the project file by appending the following line:
+Modify the line with ``max_frame = 500``
+to use a different value, such as ``1000``.
+Note that you could also make this change
+in the project file by appending the following line:
 
 .. code-block:: bash
 
    feature_tracker:max_frames = 1000
 
-Note that the "max_frames" parameter is in the "feature_tracker" scope and scope must be specified either using block/endblock notation or with a prefix before a colon.
+Note that the ``max_frames`` parameter is in the ``feature_tracker`` scope
+and scope must be specified either using ``block``/``endblock`` notation
+or with a prefix before a colon.
 
 Printing all KLV metadata
 ===========================
 
-The TeleSculptor application loads KLV metadata and display it in a viewer, but there is no way to export this data in batch.  However, the installer does provide the kwiver command
-line tool that has an applet that will print out all metadata in a video.  This applet is called “dump_klv”. The default installation path is
+The TeleSculptor application loads KLV metadata and display it in a viewer,
+but there is no way to export this data in batch.
+However, the installer does provide the kwiver command line tool
+that has an applet that will print out all metadata in a video.
+This applet is called :path:`dump_klv`.
+The default installation path is:
 
-**C:\\Program Files\\TeleSculptor** |space| |version| **\\bin\\kwiver.exe**
+.. parsed-literal::
+  :class: wrap
 
-To run dump_klv, open up a command prompt (search for cmd.exe in the Start Menu).  Then run
+  C: |backslash| Program Files |backslash| TeleSculptor |version|
+  |backslash| bin |backslash| kwiver.exe
 
-**“C:\\Program Files\\TeleSculptor** |space| |version| **\\bin\\kwiver.exe” dump_klv video_file.mpeg**
+To run :path:`dump_klv`, open up a command prompt
+(search for "cmd.exe" in the Start Menu).
+Then run:
 
-and replace “video_file.mpeg” with the path to the video file to process.  This will print out all the metadata.  To redirect the output to a file use:
+.. parsed-literal::
 
-**“C:\\Program Files\\TeleSculptor** |space| |version| **\\bin\\kwiver.exe” dump_klv.exe video_file.mpeg > metadata.txt**
+  "C: |backslash| Program Files |backslash| TeleSculptor |version|
+  |backslash| bin |backslash| kwiver.exe" \
+  dump_klv video_file.mpeg
+
+and replace :path:`video_file.mpeg`
+with the path to the video file to process.
+This will print out all the metadata.
+To redirect the output to a file use:
+
+.. parsed-literal::
+
+  "C: |backslash| Program Files |backslash| TeleSculptor |version|
+  |backslash| bin |backslash| kwiver.exe" \
+  dump_klv video_file.mpeg > metadata.txt

--- a/doc/images/icon.svg
+++ b/doc/images/icon.svg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="icon.svg"
+   version="1.1"
+   width="128"
+   height="128"
+   viewBox="0 0 128 128">
+  <defs>
+    <inkscape:path-effect
+       id="path-effect-spiro"
+       effect="spiro"
+       is_visible="true"
+       lpeversion="0" />
+  </defs>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     x="0"
+     y="0"
+     width="128"
+     height="128" />
+  <g>
+    <ellipse
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#088442;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       cx="64"
+       cy="110.5"
+       rx="42.5"
+       ry="11" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#088442;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 21.5,110.5 v -8 h 85 v 8" />
+    <ellipse
+       id="path18497"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#00a94f;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       cx="64"
+       cy="102.5"
+       rx="42.5"
+       ry="11" />
+    <path
+       class="st2"
+       style="display:inline;opacity:1;fill:#00a94f;stroke:#ffffff;stroke-linecap:round"
+       d="m 61.847305,101.12299 c 0,0 -7.162633,-11.324531 -8.793469,-13.907776 -2.04833,-3.248625 -3.927053,0.06523 -3.927053,0.06523 0,0 -8.649955,13.581606 -9.237056,14.494876" />
+    <path
+       inkscape:original-d="m 61.09375,99 c 0,0 -3.298327,0.914074 -4.961326,1.31657 -3.097379,0.74966 -6.611499,0.3969 -9.339206,2.04473 -1.065931,0.64394 -2.565858,1.62381 -2.405273,2.85875 0.338202,2.60086 5.361409,2.13289 6.43696,4.52497 0.445376,0.99054 -0.36736,3.23741 -0.36736,3.23741 0,0 3.954533,2.0305 6.110998,2.15706 2.336833,0.13715 6.850097,-1.54679 6.850097,-1.54679 0,0 -1.863956,-4.03643 -3.579728,-5.3033 -2.604752,-1.92326 -6.323311,-1.53603 -9.293995,-2.82394 -0.514802,-0.22319 -1.328261,-0.29518 -1.458134,-0.84104 -0.172298,-0.72418 0.614375,-1.44123 1.224694,-1.86741 1.992619,-1.39145 4.777665,-0.9407 7.101021,-1.65391 1.311083,-0.40247 3.840627,-1.47576 3.840627,-1.47576 z"
+       inkscape:path-effect="#path-effect-spiro"
+       sodipodi:nodetypes="caaaacacaaaaacc"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#10509c;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 61.09375,99 c -1.617171,0.563905 -3.277338,1.00446 -4.961326,1.31657 -3.143314,0.58258 -6.423419,0.734 -9.339206,2.04473 -0.604718,0.27184 -1.197677,0.59891 -1.658923,1.07518 -0.230623,0.23813 -0.42601,0.51245 -0.559456,0.8159 -0.133445,0.30346 -0.203854,0.6366 -0.186894,0.96767 0.01767,0.34492 0.129961,0.68218 0.305805,0.97944 0.175844,0.29726 0.414019,0.5553 0.684188,0.77046 0.540336,0.43031 1.197876,0.68578 1.85754,0.89067 0.659664,0.20488 1.335202,0.3665 1.969949,0.63895 0.634747,0.27245 1.237845,0.6697 1.619478,1.24545 0.325869,0.49162 0.472175,1.09953 0.405673,1.68558 -0.0665,0.58606 -0.345295,1.14572 -0.773033,1.55183 1.794069,1.2498 3.929908,2.0037 6.110998,2.15706 2.36867,0.16654 4.782821,-0.37858 6.850097,-1.54679 -0.506686,-2.11962 -1.803407,-4.04069 -3.579728,-5.3033 -1.331284,-0.94628 -2.895234,-1.51817 -4.481199,-1.90865 -1.585965,-0.39049 -3.208361,-0.60943 -4.812796,-0.91529 -0.287955,-0.0549 -0.578863,-0.11373 -0.843279,-0.24029 -0.264415,-0.12655 -0.503579,-0.32955 -0.614855,-0.60075 -0.07819,-0.19057 -0.08882,-0.4058 -0.04417,-0.60689 0.04465,-0.2011 0.142848,-0.38829 0.271381,-0.54926 0.257066,-0.32194 0.625428,-0.53432 0.997479,-0.71126 2.201446,-1.04699 4.731277,-1.08218 7.101021,-1.65391 1.336984,-0.32256 2.631659,-0.82004 3.840627,-1.47576 z" />
+    <path
+       class="st2"
+       style="display:inline;opacity:1;fill:#00a94f;stroke:#ffffff;stroke-linecap:round"
+       d="m 88.945278,103.53662 c 0,0 -10.228605,-16.621479 -12.916222,-20.287599 -2.687618,-3.653073 -4.696809,0 -4.696809,0 0,0 -13.398949,20.548539 -14.325264,21.853209" />
+    <path
+       inkscape:original-d="m 50.457545,112.98243 c 0,0 3.954533,2.0305 6.110998,2.15706 2.336833,0.13715 6.850097,-1.54679 6.850097,-1.54679"
+       inkscape:path-effect="#path-effect-spiro"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#082950;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 50.457545,112.98243 c 1.794069,1.2498 3.929908,2.0037 6.110998,2.15706 2.36867,0.16654 4.782821,-0.37858 6.850097,-1.54679" />
+  </g>
+  <g>
+    <path
+       id="rect10900"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#10509c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 27,38 h 15 l 4,8 H 36 Z" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#10509c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 15,27 h 26 v 8 H 24 Z" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#10509c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 3,16 h 43 l -4,8 H 12 Z" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#10509c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 101,38 H 86 l -4,8 h 10 z" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#10509c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 113,27 H 87 v 8 h 17 z" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#10509c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 125,16 H 82 l 4,8 h 30 z" />
+    <circle
+       id="path10896"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#10509c;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       cx="64"
+       cy="32"
+       r="23" />
+  </g>
+  <g
+     style="display:inline">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 48,68 60,40 h 8 l 12,28 -8,4 H 56 Z" />
+    <ellipse
+       id="path10953"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#10509c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       cx="64"
+       cy="68.5"
+       rx="11"
+       ry="4.5" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#8e8e8e;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 58,36.5 -25,65 17.5,-29 L 63,40 Z" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#8e8e8e;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 70,36.5 25,65 L 77.5,72.5 65,40 Z" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#8e8e8e;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       x="61.5"
+       y="6.5"
+       width="5"
+       height="18" />
+    <circle
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       cx="64"
+       cy="32"
+       r="8" />
+    <circle
+       id="path10919"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#8e8e8e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       cx="64"
+       cy="32"
+       r="8" />
+    <path
+       sodipodi:arc-type="arc"
+       sodipodi:cx="64"
+       sodipodi:cy="32"
+       sodipodi:end="1.9722221"
+       sodipodi:open="true"
+       sodipodi:rx="41"
+       sodipodi:ry="41"
+       sodipodi:start="0.9250245"
+       sodipodi:type="arc"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:6;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 88.674416,64.744056 A 41,41 0 0 1 47.980022,69.740698" />
+    <path
+       sodipodi:arc-type="arc"
+       sodipodi:cx="64"
+       sodipodi:cy="32"
+       sodipodi:end="1.9722221"
+       sodipodi:open="true"
+       sodipodi:rx="41"
+       sodipodi:ry="41"
+       sodipodi:start="0.9250245"
+       sodipodi:type="arc"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#8e8e8e;stroke-width:4;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 88.674416,64.744056 A 41,41 0 0 1 47.980022,69.740698" />
+  </g>
+</svg>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,45 +1,65 @@
-.. TeleSculptor documentation master file, created by
-   sphinx-quickstart on Wed Mar 31 23:56:53 2021.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-.. include:: version.rst
-
 TeleSculptor
 ============
 
-.. image:: /../gui/icons/256x256/telesculptor.png
+.. image:: images/icon.svg
+   :height: 256px
+   :width: 256px
    :align: right
 
 Introduction
 ------------
 
-Welcome to TeleSculptor.  This software is free and open source software developed by Kitware under multiple SBIR contracts for DARPA and AFRL.  The purpose of the software is to
-calibrate cameras and extract 3D information from video and images, especially aerial video.  The software is designed to have different workflows that can either improve the manual
-modelling process in SketchUp or provide fully automatic 3D reconstruction.
+Welcome to TeleSculptor.
+This software is free and open source software
+developed by Kitware under multiple SBIR contracts for DARPA and AFRL.
+The purpose of the software is to calibrate cameras and extract 3D information
+from video and images, especially aerial video.
+The software is designed to have different workflows
+that can either improve the manual modelling process in SketchUp
+or provide fully automatic 3D reconstruction.
 
-TeleSculptor v |version| |space| marks the second official release of the software. There are several improvements to the application interface and algorithm robustness since the previous v1.0
-release.  Please refer to the release notes file for details on all the changes.  While TeleSculptor continues to become more broadly useful across imaging scenarios, it is still
-optimized for the use case of aerial video flying a 360-degree orbit around a target object.  TeleSculptor will give best results on a video clip containing one orbit around an
-object.  We will improve robustness on more general imaging scenarios in future releases.
+TeleSculptor is a cross-platform desktop application
+for Windows, Linux, and Mac.
+This document uses the Windows version of the application to illustrate usage,
+but everything should work nearly the same on other platforms.
 
-TeleSculptor is a cross-platform desktop application for Windows, Linux, and Mac.  This document uses the Windows version of the application to illustrate usage, but everything should
-work nearly the same on other platforms.
+.. TODO the following should link to the release notes; `Release Notes`_
+
+TeleSculptor v\ |version| marks the third official release of the software.
+Please refer to the Release Notes for details on all the changes.
+While TeleSculptor continues to become
+more broadly useful across imaging scenarios,
+it is still optimized for the use case of aerial video
+flying a 360-degree orbit around a target object.
+TeleSculptor will give best results on a video clip
+containing one orbit around an object.
+We will improve robustness on more general imaging scenarios
+in future releases.
 
 Branding: Origins and Destinations
 ----------------------------------
 
-TeleSculptor has its origins in a software project developed as “MAP-Tk”, the Motion-imagery Aerial Photogrammetry Toolkit.  The original software was not an end user application but
-a collection of developer tools and libraries.  As the software evolved it developed a graphical application that we now call TeleSculptor.  At the same time, the software libraries
-of MAP-Tk were reorganized into a new, broader toolkit called KWIVER (Kitware Image and Video Exploitation and Retrieval).  So, the original MAP-Tk has dissolved away leaving behind a
-TeleSculptor application powered by KWIVER.  However, some uses of the name MAP-Tk may persist for historical reasons.
+TeleSculptor has its origins in a software project developed as "MAP-Tk",
+the Motion-imagery Aerial Photogrammetry Toolkit.
+The original software was not an end user application
+but a collection of developer tools and libraries.
+As the software evolved, it developed a graphical application
+that we now call TeleSculptor.
+At the same time, the software libraries of MAP-Tk
+were reorganized into a new, broader toolkit called KWIVER_
+(Kitware Image and Video Exploitation and Retrieval).
+So, the original MAP-Tk has dissolved away
+leaving behind a TeleSculptor application powered by KWIVER.
+However, some uses of the name MAP-Tk may persist for historical reasons.
 
 Getting Started
 ---------------
 
-* For instructions on how to install Telesculptor, see :ref:`Installation <installation>`.
+* For instructions on how to install Telesculptor,
+  see :ref:`Installation <installation>`.
 
-* To start a new Telesculptor project, see :ref:`Processing Steps <processingsteps>`.
+* To start a new Telesculptor project,
+  see :ref:`Processing Steps <processingsteps>`.
 
 .. toctree::
    :maxdepth: 2
@@ -53,3 +73,5 @@ Getting Started
    computeoptions
    advancedconfig
    cameracalibration
+
+.. _KWIVER: https://www.kwiver.org

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,17 +1,19 @@
 .. _installation:
 
-.. include:: version.rst
-
 .. image:: /images/telesculptor_install_icon.png
    :scale: 60 %
    :align: right
 
-===========================
+=========================
 TeleSculptor Installation
-===========================
+=========================
 
-The TeleSculptor software uses a standard installer package on Windows. To install, double click the installer icon and step through the installation steps as shown in the images
-below. This will require administrative privileges. The name of the 64-bit Windows installer is **TeleSculptor-** |version| **-Windows-AMD64.exe**.
+The TeleSculptor software uses a standard installer package on Windows.
+To install, double click the installer icon
+and step through the installation steps as shown in the images below.
+This will require administrative privileges.
+The name of the 64-bit Windows installer
+is :path:`TeleSculptor-\ |version|\ -Windows-AMD64.exe`.
 
 .. figure:: /images/telesculptor_install_1.png
    :align: center
@@ -23,7 +25,7 @@ below. This will require administrative privileges. The name of the 64-bit Windo
    :align: center
    :scale: 80 %
 
-   \2. Click “I Agree” to accept the BSD license
+   \2. Click "I Agree" to accept the BSD license
 
 .. figure:: /images/telesculptor_install_3.png
    :align: center
@@ -49,29 +51,50 @@ below. This will require administrative privileges. The name of the 64-bit Windo
 
    \6. Click "Finish" to complete
 
-To run the application, find TeleSculptor in the Start Menu and click the icon.  The program will open with an appearance as shown below.
+To run the application,
+find TeleSculptor in the Start Menu and click the icon.
+The program will open with an appearance as shown below.
 
 .. figure:: /images/application_opened.png
    :align: center
 
    *The TeleSculptor Application when first opened.*
 
-Once the application is open you can access additional documentation about the various features in the User Manual which is opened from the *Help* menu or by pressing the F1 shortcut
-key.  The User Manual will open in your default web browser.  The User Manual does not yet provide step-by-step instructions, as this document does, but it does provide more detailed
-descriptions of each of the buttons and menu options.
+Once the application is open,
+you can access this documentation from the *Help* menu
+or by pressing the F1 shortcut key.
 
 SketchUp Plugin Installation
-==============================
+============================
 
-The TeleSculptor application also comes with a plugin for SketchUp that allows SketchUp to read TeleSculptor project files.  This is not installed automatically.  To install the
-SketchUp plugin, first locate the plugin in your TeleSculptor installation.  If TeleSculptor is installed in the default location, you will find the plugin at
+The TeleSculptor application also comes with a plugin for SketchUp
+that allows SketchUp to read TeleSculptor project files.
+This is not installed automatically.
+To install the SketchUp plugin,
+first locate the plugin in your TeleSculptor installation.
+If TeleSculptor is installed in the default location,
+you will find the plugin at:
 
-**C:\\Program Files\\TeleSculptor** |space| |version| **\\share\\telesculptor\\** |version| **\\plugins\\sketchup\\kw_telesculptor.rbz**
+.. parsed-literal::
+  :class: wrap
 
-To install this plug in SketchUp, first open SketchUp.  Next navigate to the *Window->Preferences* menu as shown in the figure below.  Within the *System Preferences* dialog, click
-on Extensions in the menu on the left.  Now click the Install Extension button at the bottom of the dialog.  Use the file open dialog to locate the kw_telesculptor.rbz file at the
-location above and click the Open button.  Administrative privileges are needed to complete the installation.  Once installed “TeleSculptor Importer” will appear in the Extensions
-list and the box next to it should be checked to activate the plugin.  The plugin may not be fully active until the SketchUp application is closed and re-opened.
+  C: |backslash| Program Files |backslash| TeleSculptor |version|
+  |backslash| share |backslash| telesculptor |backslash| |version|
+  |backslash| plugins |backslash| sketchup |backslash| kw_telesculptor.rbz
+
+To install this plug in SketchUp, first open SketchUp.
+Next navigate to the *Window* |rarrow| *Preferences* menu
+as shown in the figure below.
+Within the *System Preferences* dialog,
+click on Extensions in the menu on the left.
+Now click the Install Extension button at the bottom of the dialog.
+Use the file open dialog to locate the :path:`kw_telesculptor.rbz` file
+at the location above and click the Open button.
+Administrative privileges are needed to complete the installation.
+Once installed, "TeleSculptor Importer" will appear in the Extensions list
+and the box next to it should be checked to activate the plugin.
+The plugin may not be fully active
+until the SketchUp application is closed and re-opened.
 
 .. figure:: /images/sketchup_preferences.png
    :align: center

--- a/doc/processingsteps.rst
+++ b/doc/processingsteps.rst
@@ -39,19 +39,27 @@
 
 .. |horizontal_caption| replace:: Horizontal Constraint (hold X or Y)
 
-==================
+================
 Processing Steps
-==================
+================
 
-This section describes how to run the key processing steps and what each step does.  The previous section describes which of these steps you should run, and in which order, depending
-on the desired goals.  However, processing step are generally run in the order listed below, with some steps only needed for one workflow or another.
+This section describes how to run the key processing steps
+and what each step does.
+The previous section describes which of these steps you should run,
+and in which order, depending on the desired goals.
+However, processing step are generally run in the order listed below,
+with some steps only needed for one workflow or another.
 
 Create a New Project
-======================
+====================
 
-The TeleSculptor application requires a working directory, also called the project folder, in which to save settings and algorithm results when processing a video.  To create a new
-project use the *File->New Project* menu item or keyboard shortcut Ctrl+N.  Create a new empty folder at the desired location and press the “Select Folder” button with that new
-folder highlighted.
+The TeleSculptor application requires a working directory,
+also called the project folder,
+in which to save settings and algorithm results when processing a video.
+To create a new project use the *File* |rarrow| *New Project* menu item
+or keyboard shortcut Ctrl+N.
+Create a new empty folder at the desired location
+and press the "Select Folder" button with that new folder highlighted.
 
 .. figure:: /images/new_project.png
    :align: center
@@ -114,9 +122,16 @@ the visibility, size, and color of camera path, camera frustums, and active came
 Run End-to-End
 ================
 
-Run End-to-End is a new feature in TeleSculptor v |version| .  Rather than waiting for user input to run each if the primary processing steps, Run End-to-End automatically runs Track
-Features, Estimate Cameras/Landmarks, Batch Compute Depth Maps, and Fuse Depth Maps.  These steps are run sequential in this order.  See details of these steps in their respective
-sections below.
+Run End-to-End is a new feature in TeleSculptor v\ |version|.
+Rather than waiting for user input
+to run each of the primary processing steps,
+Run End-to-End automatically runs
+Track Features,
+Estimate Cameras/Landmarks,
+Batch Compute Depth Maps,
+and Fuse Depth Maps.
+These steps are run sequentially in this order.
+See details of these steps in their respective sections below.
 
 .. figure:: /images/end_to_end.png
    :align: center

--- a/doc/replacements.rst
+++ b/doc/replacements.rst
@@ -1,0 +1,6 @@
+.. backslash followed by zero-width space; to help Windows paths wrap better
+.. |backslash| unicode:: 0x5C U+200B
+  :trim:
+
+.. rightwards arrow
+.. |rarrow| unicode:: U+2192

--- a/doc/version.rst
+++ b/doc/version.rst
@@ -1,5 +1,0 @@
-.. |version| unicode:: 1.1.0
-   :trim:
-
-.. |space| unicode:: 0xA0
-   :trim:


### PR DESCRIPTION
Start cleaning up the RTD documentation. In addition to a major change to how the source is written (which does not affect output; see below for details), the following changes are made:

- Specification of the application version is moved to `conf.py`, where it belongs. A KWIVER version is added to the same location. This gives us a single place, at least within the RTD contents, where version numbers and copyright year need to be kept up to date.
- Uses of the version number are updated. `|space|` is removed; it isn't needed, especially with use of the built-in `|version|`.
- Formatting of file paths is improved. (Custom CSS is added for this.) Some initial improvements to formatting of references to UI elements (particularly, replacing `->` with `→`) are also made. (Eventually I would like to systematize formatting of menu and keyboard-shortcut references, but that is low priority.)
- The large PNG logo is replaced with a slimmed-down version of the SVG, which will render better across different screen resolutions. (We should do this with the title logo, also, but likewise low priority, particularly as I don't know where the source for that logo lives.)
- The KWIVER reference in the root page is now a link.

Last, this starts to aggressively reformat the reST source to improve ongoing maintenance. Since line breaks in the source do not affect the output, we should, just like we would do with C++ source code, use line breaks in a way that is beneficial to maintenance of the source. This means keeping lines to a reasonable length, and also inserting breaks in a way that will minimize "churn" from editing. (Specifically, ***not*** keeping text as tightly wrapped as possible such that changes are likely to reflow entire paragraphs. This is in contrast to text expected to be read primarily "in the raw", such as plain text documents or source code comments.) To that end, breaks should ***always*** be added at the end of sentences, and also at "logical" places within sentences which would otherwise be longer than the desired line length.

On a similar note, use of smart quotes is strongly discouraged *in the source*. These are a pain to type, and Sphinx will generate these automatically in the final documentation. Also, in some instances (e.g. text meant to be entered at a command prompt) they are outright wrong. These will be replaced with ASCII quotes as the above changes are rolled out.

The plan is to apply such reformatting to all documentation source files eventually, but for now only those files affected by the other changes have been (in some cases, partly) modified.

The effect of these changes should be visible in the RTD job.