### PR TITLE
Overhaul camera calibration documentation and improve polish

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1,3 +1,7 @@
+p {
+  text-align: justify;
+}
+
 pre.wrap {
   white-space: pre-wrap !important;
 }

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -20,3 +20,53 @@ pre.literal-block,
   border: 1px solid #e1e4e5;
   padding: 2px 5px;
 }
+
+.menu {
+  background: #f8fbfc;
+  padding: 0.1em 0.3em;
+  border: 1px solid #f4f7f8;
+  font-style: italic;
+}
+
+.action {
+  background: #f4f4f4;
+  padding-left: 0.3em;
+  padding-right: 0.3em;
+  border: 1px solid #e1e4e5;
+  border-radius: 0.4em;
+  font-weight: 700;
+}
+
+img.icon-16 {
+  position: relative;
+  bottom: calc(0.5em - 7px);
+  height: 16px;
+  width: 16px;
+}
+
+.glyph {
+  position: relative;
+  bottom: calc(0.5em - 6px);
+  height: 1em;
+}
+
+.shortcut {
+  background: #eceff0;
+  padding: 0.1em 0.3em;
+  border: 1px solid;
+  border-color: #f4f7f8 #e1e4e5 #e1e4e5 #f4f7f8;
+  border-radius: 0.4em;
+  font-weight: 700;
+  font-size: 80%;
+  position: relative;
+  top: -0.05em;
+}
+
+.math {
+  font-family: math, serif;
+  font-style: italic;
+}
+
+.math.script {
+  font-family: cursive, math, serif;
+}

--- a/doc/advancedconfig.rst
+++ b/doc/advancedconfig.rst
@@ -1,7 +1,5 @@
 .. _advancedconfig:
 
-.. include:: version.rst
-
 ==============================
 Advanced Configuration Options
 ==============================

--- a/doc/advancedtools.rst
+++ b/doc/advancedtools.rst
@@ -59,7 +59,8 @@ detect and correct for this ambiguity, so this the manual correction is rarely n
 .. figure:: /images/necker_reversal_after.png
    :align: center
 
-   *Effect of Necker Reversal on camera orbits.  Bottom cameras are flipped and upside down.*
+   Effect of Necker Reversal on camera orbits.
+   Bottom cameras are flipped and upside down.
 
 Align
 =======

--- a/doc/cameracalibration.rst
+++ b/doc/cameracalibration.rst
@@ -4,85 +4,147 @@
 Manual Camera Calibration
 =========================
 
-This section describes the functions for manaul camera calibration capabilities in TeleSculptor (TS)
-and steps to achieve, possibly correct, and export a camera calibration model.
+This section describes the functions
+for manual camera calibration capabilities in TeleSculptor (TS)
+and steps to achieve, possibly correct, and export
+a camera calibration model.
 
 Preparation
 ===========
 
-TeleSculptor can work with ffmpeg-readable videos (e.g. mpg, mp4, avi) or with image sequences.
-The latter can be specified by listing paths to individual images in a plain text file (e.g. images.txt)
-using one line per path/to/image/file. Standard image formats (e.g. bmp, png, jpg) are supported.
+TeleSculptor can work with ffmpeg-readable videos
+(e.g. mpg, mp4, avi) or with image sequences.
+The latter can be specified by listing paths to individual images
+in a plain text file (e.g. images.txt) using one line per path/to/image/file.
+Standard image formats (e.g. bmp, png, jpg) are supported.
 
-TeleSculptor has a capability to import PLY mesh or point cloud files via File/Import/Mesh.
+TeleSculptor has a capability to import PLY mesh or point cloud files
+via :menu:`File` |rarrow| :menu:`Import` |rarrow| :menu:`Mesh`.
 Point clouds are imported as faceless meshes.
-The imported mesh is used as a 3D target for calibration. RGB[A] color space is currently supported.
+The imported mesh is used as a 3D target for calibration.
+RGB[A] color space is currently supported.
 The alpha channel can be used to set mesh transparency levels.
 
-We recommend geo-registering the mesh before importing it to TS to have the output calibrated
-camera parameters in mesh metric units and also automatically geo-registered with the 3D model.
+We recommend geo-registering the mesh before importing it into TS
+to have the output calibrated camera parameters in mesh metric units
+and also automatically geo-registered with the 3D model.
 
 Calibration
 ===========
 
-Start the TeleSculptor GUI and proceed with the following steps in a new or an existing project.
-
-.. |gcp_button| image:: /../gui/icons/22x22/location.png
+Start the TeleSculptor GUI and proceed with the following steps
+in a new or an existing project.
 
 New project
 -----------
 
-Choose menu: File/New Project… (Ctrl+N) and select a folder for the new project,
-creating one if necessary. The project ini file name would have the same name by default.
+Create a new project using :menu:`File` |rarrow| :menu:`New Project`
+(:shortcut:`Ctrl+N`)
+and select a folder for the new project, creating one if necessary.
+The project :path:`.ini` file name will have the same name by default.
 
-Choose menu: File/Import/Imagery… (Ctrl+O,I) and select a video or an image sequence text file.
-Large videos would imply a long search for metadata, which can be canceled via menu: Compute/Cancel.
+Select a video or image sequence text file
+using :menu:`File` |rarrow| :menu:`Import` |rarrow| :menu:`Imagery...`
+(:shortcut:`Ctrl+O, I`).
+Opening a large videos will initiate a potentially long search for metadata,
+which may be canceled via the menu action
+:menu:`Compute` |rarrow| :menu:`Cancel`.
 
-Choose menu: File/Import/Mesh… (Ctrl+O,M) and select an PLY file with a mesh or a point cloud,
-which should appear in the 3D viewer.
+Select a PLY file with a mesh or a point cloud
+using :menu:`File` |rarrow| :menu:`Import` |rarrow| :menu:`Mesh...`
+(:shortcut:`Ctrl+O, M`).
+The loaded 3D geometry should appear in the 3D world view.
 
-Scroll to the desired video/image frame using the Camera Selection slider
-and observe it in the Camera View pane. Rotate the 3D model to the desired view,
-e.g. resembling the current image.
+Locate the desired video frame or image
+using the scrubber or spin box in the Camera Selection pane.
+Rotate the model in the world view as needed
+so the desired point correspondences are visible.
 
-To place/edit ground control points (GCP), click the 3D viewer GCP tool |gcp_button|
-to start GCP creation and editing. Use Ctrl+click to place GCP buttons.
-Drag them as needed to refine their locations.
-Place six or more GCPs on the 3D model at the feature points visible from the camera view,
-observe their IDs appear in the Ground Control Points list, name them, if desired.
+Select :action:`location Edit Ground Control Points` (in the world view)
+to activate editing mode for ground control points in the world view.
+Place points using :shortcut:`Ctrl+Click`.
+Telesculptor attempts to place points "on" the loaded mesh,
+but it may be helpful to rotating the world view
+to verify that points are placed in the right 3D location.
+While editing, points may be dragged as needed.
+Newly placed points will appear in the Ground Control Points list,
+and may be given names if desired.
 
-To build 3D-2D point correspondences, click camera registration points (CRP) tool |gcp_button|
-in the Camera View.
-For each GCP in the list (also highlighted in the 3D viewer):
-select a 3D point, then click on the Camera View image, where its 2D projection is expected to be.
-Use Ctrl+click to place a CRP, and drag it with the mouse to refine its location.
-Observe the target-like icon in the GCP list for the 3D point having a corresponding 2D point.
-Select another 3D GCP and create-click-move its 2D counterpart.
-Continue with the 3D-2D correspondence process until the count of 6 or more.
+To create 3D-to-2D point correspondences,
+select :action:`location Edit Registration Points` (in the camera view).
+Ensure that the desired 3D point is selected in the Ground Control Points list
+(the selected point is highlighted in a different color).
+Place a corresponding point using :shortcut:`Ctrl+Left Click`,
+positioned to match the location in the camera image
+to which the 3D ground control point would be projected.
+The Ground Control Points list will show a glyph (|glyph-registered|)
+to indicate that the point has a corresponding camera registration point
+associated with the active video frame or image.
+Once created, points may be dragged as needed
+to fine tune their locations.
+Select another 3D ground control point and repeat
+until at least six correspondences have been created
+for the active video frame or image.
+The relevant edit mode actions may be used at any time
+to switch between editing points in the camera or world views.
 
-In the Camera View, select the [Place/edit CRP] drop-down [Compute Camera] to invoke the calibration process.
-Check the Log Viewer for the re-projection error or for any error messages, e.g. not enough calibration points.
-Observe the 3D viewer for the image projection corresponding to the newly calibrated camera.
-Click the tree-expandable marker in the GCP list next to a GCP point to see the frame numbers
-this point was used in for camera calibration.
-Double-Click on the desired frame number to jump to that frame.
+Once six or more correspondences have been defined,
+the camera pose calibration process may be invoked
+from the :menu:`Compute Camera` action located in the drop-down
+associated with :action:`location Edit Registration Points`.
+Check the Log Viewer for the re-projection error
+or for any error messages (e.g. insufficient calibration points).
+Upon successful calibration,
+the world view will show the projected camera image
+(if :action:`image Show Camera Frame Image` is enabled),
+and the camera view will show the ground control points
+projected onto the camera image.
+
+.. TODO move to interface documentation
+
+    Click the tree-expandable marker in the GCP list next to a GCP point
+    to see the frame numbers this point was used in for camera calibration.
+    Double-Click on the desired frame number to jump to that frame.
 
 .. image:: /screenshot/telesculptor_screenshot_calibration.png
-   :alt: Manual Camera Calibration Screenshot
+  :alt: Manual Camera Calibration Screenshot
 
-Move 3D and/or 2D points to adjust the camera calibration as needed.
-Zoom in and out, if necessary in both 3D and 2D views.
-Scroll to a different frame and repeat the camera calibration process.
+Repeat this process on additional frames.
+Point locations may be adjusted as needed, as described above,
+to refine the camera pose calibration.
+Camera calibrations may be refined at any time;
+it is not necessary to "finalize" one camera pose
+before calibrating additional camera poses.
 
-Choose menu: File/Export/KRTD Cameras… to output the parameters of all calibrated cameras to KRTD text files,
-each capturing the intrinsic matrix K, Rotation matrix, Translation vector and lens Distortion parameters.
+When satisfied,
+:menu:`File` |rarrow| :menu:`Export` |rarrow| :menu:`KRTD Cameras...`
+may be used to save the parameters of all calibrated cameras
+to KRTD text files.
+Each file will capture
+the intrinsic matrix :var:`K`,
+the rotation matrix,
+the translation vector
+and the lens Distortion parameters.
 
-Choose menu: File/Export/Ground Control Points… to output all the GCPs
-and their corresponding 2D CRPs for each frame 3D-2D correspondence were built.
+:menu:`File` |rarrow| :menu:`Export` |rarrow| :menu:`Ground Control Points...`
+will export all of the ground control points
+and their corresponding camera registration points
+as a GeoJSON_-like file.
+(Only the geodetic locations, if available, conform to GeoJSON;
+the world and camera locations are stored as extensions.)
+This will output all points,
+whether or not calibration was performed successfully.
 
 Existing project
 ----------------
-Choose, menu: File/Open Project… (Ctrl+O,P) to open an existing project,
-its corresponding video/image sequence and the 3D mesh or point cloud,
-which are loaded automatically.
-Follow the calibration procedure described in the New project section.
+
+Open an existing project using :menu:`File` |rarrow| :menu:`Open Project...`
+(:shortcut:`Ctrl+O, P`).
+The project's corresponding video or image sequence,
+and the 3D mesh or point cloud, will be loaded automatically.
+Follow the calibration procedure described for new projects, above.
+
+.. |glyph-registered| image:: images/registered.svg
+  :class: glyph
+
+.. _GeoJSON: https://geojson.org/

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,7 +44,11 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = [
+    'Thumbs.db',
+    '.DS_Store',
+    'replacements.rst',
+]
 
 rst_epilog = f'''
 .. include:: replacements.rst

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,7 +4,9 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-from docutils import nodes
+import os.path
+
+from docutils import nodes, utils
 from docutils.parsers.rst.states import Struct
 
 # -- Path setup --------------------------------------------------------------
@@ -90,6 +92,55 @@ master_doc = 'index'
 
 # -- Customizations ----------------------------------------------------------
 
+icon_root = '../gui/icons'
+icon_sizes = [22, 16]
+srcdir = ''
+
+def locate_icon(name, size):
+    for d in [f'{size}x{size}@2', f'{size}x{size}']:
+        p = os.path.join(icon_root, d, f'{name}.png')
+        print(p)
+        if os.path.isfile(os.path.join(srcdir, p)):
+            return p
+
+    return None
+
+def build_icon(rawtext, text, lineno, inliner, options={}, sizes=icon_sizes):
+    if text in ['-', 'blank']:
+        return None
+
+    options['alt'] = utils.unescape(text)
+    for s in sizes:
+        uri = locate_icon(text, s)
+        print(s, uri)
+        if uri is not None:
+            options['uri'] = uri
+            options['classes'] = [f'icon-{s}']
+            return nodes.image(rawtext, **options)
+
+    return None
+
+def action_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    parts = text.split()
+    print(parts)
+
+    # Build icon element
+    icon = build_icon(rawtext, parts[0], lineno, inliner, sizes=[16, 22])
+
+    # Create node
+    options['classes'] = ['action']
+    node = nodes.inline(rawtext, '', **options)
+
+    if icon is not None:
+        node += icon
+        node += nodes.Text(' ', ' ')
+
+    title = ' '.join(parts[1:])
+    node += nodes.Text(title, title)
+
+    # Return resulting node
+    return [node], []
+
 def make_parsed_text_role(class_names=[], node_class=nodes.inline):
     def parsed_text_role(name, rawtext, text, lineno, inliner,
                          options={}, content=[]):
@@ -112,4 +163,13 @@ def make_parsed_text_role(class_names=[], node_class=nodes.inline):
     return parsed_text_role
 
 def setup(app):
+    global srcdir
+    srcdir = app.srcdir
+
+    app.add_role('var', make_parsed_text_role(class_names=['math', 'script']))
+    app.add_role('math', make_parsed_text_role(class_names=['math']))
     app.add_role('path', make_parsed_text_role(class_names=['filepath']))
+    app.add_role('menu', make_parsed_text_role(class_names=['menu']))
+    app.add_role('shortcut', make_parsed_text_role(class_names=['shortcut']))
+
+    app.add_role('action', action_role)

--- a/doc/images/registered.svg
+++ b/doc/images/registered.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="registered.svg"
+   version="1.1"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16">
+  <g
+     id="group">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1"
+       d="M 9.1995932,3.2691815 A 5.5,5.5 0 0 1 12.730811,6.8003987" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1px"
+       d="M 7.5,7 V 1.5" />
+  </g>
+  <use
+     xlink:href="#group"
+     transform="rotate(-90,7.5,8.5)" />
+  <use
+     xlink:href="#group"
+     transform="rotate(180,7.5,8.5)" />
+  <use
+     xlink:href="#group"
+     transform="rotate(90,7.5,8.5)" />
+</svg>

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -58,7 +58,7 @@ The program will open with an appearance as shown below.
 .. figure:: /images/application_opened.png
    :align: center
 
-   *The TeleSculptor Application when first opened.*
+   The TeleSculptor Application when first opened.
 
 Once the application is open,
 you can access this documentation from the *Help* menu
@@ -100,16 +100,18 @@ until the SketchUp application is closed and re-opened.
    :align: center
    :width: 80 %
 
-   *Access the SketchUp Preferences to install the TeleSculptor plugin.*
+   Access the SketchUp Preferences to install the TeleSculptor plugin.
 
 .. figure:: /images/telesculptor_importer.png
    :align: center
    :width: 80 %
 
-   *TeleSculptor Importer installed and activated in the SketchUp Extensions list in System Preferences.*
+   TeleSculptor Importer installed and activated
+   in the SketchUp Extensions list in System Preferences.
 
 .. figure:: /images/import_telesculptor_project.png
    :align: center
    :width: 80 %
 
-   *The Import TeleSculptor Project option in the Plugins menu after installing the extension.*
+   The Import TeleSculptor Project option in the Plugins menu
+   after installing the extension.

--- a/doc/processingsteps.rst
+++ b/doc/processingsteps.rst
@@ -1,7 +1,5 @@
 .. _processingsteps:
 
-.. include:: version.rst
-
 .. |image_button| image:: /../gui/icons/16x16/image.png
 
 .. |cameras_button| image:: /../gui/icons/16x16/camera.png
@@ -15,7 +13,7 @@
 .. |copy_location_button| image:: /../gui/icons/16x16/copy-location.png
 
 .. |icon| image:: /images/icon.png
-   :scale: 55 %
+   :scale: 55%
 
 .. |reset_button| image:: /../gui/icons/16x16/reset.png
 
@@ -30,10 +28,10 @@
 .. |measurement_tool| image:: /../gui/icons/22x22/ruler.png
 
 .. |vertical_constraint| image:: /images/vertical_constraint.png
-   :width: 49 %
+  :width: 50%
 
 .. |horizontal_constraint| image:: /images/horizontal_constraint.png
-   :width: 49 %
+  :width: 50%
 
 .. |vertical_caption| replace:: Vertical Constraint (hold Z)
 

--- a/doc/processingsteps.rst
+++ b/doc/processingsteps.rst
@@ -64,12 +64,12 @@ and press the "Select Folder" button with that new folder highlighted.
 .. figure:: /images/new_project.png
    :align: center
 
-   *Create a new project from the File->New Project menu item.*
+   Create a new project from the File->New Project menu item.
 
 .. figure:: /images/new_project_folder.png
    :align: center
 
-   *Create a new project folder to store the results of processing.*
+   Create a new project folder to store the results of processing.
 
 After creating the new project, the application will create a project file in the project directory with the same name and a “.conf” file extension.  In the example shown in the
 figure above it will create **MyProject/MyProject.conf**.  This conf file is known as the project file or the project configuration file.  It contains the configuration settings for
@@ -96,7 +96,7 @@ estimating these mask videos for videos with burned in metadata.
 .. figure:: /images/import_video_clip.png
    :align: center
 
-   *Import a video clip, image list, or other data.*
+   Import a video clip, image list, or other data.
 
 Once a video is selected to open, the application will scan the entire video to find all metadata.  This may take several seconds or even minutes for very large videos. If scanning
 the video takes too long or it is known that the video does not contain metadata it is okay to cancel the metadata scanning using the “Cancel” option in the Compute menu.  If
@@ -110,7 +110,7 @@ active camera model is required.  An active camera model is a camera model for t
 .. figure:: /images/video_metadata.png
    :align: center
 
-   *A video with KLV metadata opened in the application.*
+   A video with KLV metadata opened in the application.
 
 As can be seen in the image above. The aircraft flight path, as given in the metadata, is shown as a curved line in the 3D World View.  A pyramid (frustum) is shown representing the
 orientation and position of the camera at each time step.  The active camera, representing the current frame of video, is shown in a different color and is longer than the others.
@@ -136,7 +136,7 @@ See details of these steps in their respective sections below.
 .. figure:: /images/end_to_end.png
    :align: center
 
-   *Run End-to-End Option in the Compute menu.*
+   Run End-to-End Option in the Compute menu.
 
 Track Features
 ================
@@ -147,7 +147,7 @@ The Track Features tool detects visually distinct points in the image called “
 .. figure:: /images/track_features.png
    :align: center
 
-   *Run the Track Features algorithm from the Compute menu.*
+   Run the Track Features algorithm from the Compute menu.
 
 When the tool is running it will draw feature points on the current frame and slowly play through the video tracking the motion of those points as it goes.  These tracks are
 visualized as red trails in the image below.  These colors are fully customizable.  The feature tracks button ( |feature_tracks_button| ) above the Camera View enables toggling the
@@ -156,7 +156,7 @@ visibility of tracks. The drop-down menu under this button has settings for the 
 .. figure:: /images/track_features_example.png
    :align: center
 
-   *The Track Features algorithm producing tracks on a video.*
+   The Track Features algorithm producing tracks on a video.
 
 The feature tracking tool will start processing on the active frame and will run until the video is complete or until the tool is canceled with the *Cancel* option in the *Compute*
 menu.  We recommend starting with the video on frame 1 and letting the algorithm process until complete for a video clip containing approximately one orbit of the UAV above the
@@ -180,7 +180,7 @@ where the camera returns to see the same view again.
 .. figure:: /images/match_matrix.png
    :align: center
 
-   *The Match Matrix view of feature tracking results.*
+   The Match Matrix view of feature tracking results.
 
 Estimate Cameras/Landmarks
 ============================
@@ -192,7 +192,7 @@ algorithm will try to estimate a camera for every frame that was tracked and a l
 .. figure:: /images/estimate_cameras_landmarks.png
    :align: center
 
-   *Run the Estimate Cameras/Landmarks algorithm from the Compute menu.*
+   Run the Estimate Cameras/Landmarks algorithm from the Compute menu.
 
 The solution will start with a sparse set of cameras and then incrementally add more.  Live updates will show progress in the world view display.  During optimization, the landmarks
 will appear to float above (or below) the ground plane grid because the true elevation is typically not near zero.  Once the optimization is complete, a local ground height is
@@ -212,7 +212,7 @@ images, not video.  So, this step produces the image files that are needed when 
 .. figure:: /images/save_video_frame.png
    :align: center
 
-   *Save the loaded video frame as image files on disk*
+   Save the loaded video frame as image files on disk.
 
 Set Ground Control Points
 ===========================
@@ -232,7 +232,8 @@ on any point makes it active.  Hitting the *Delete* key will delete the current 
 .. figure:: /images/set_gcp.png
    :align: center
 
-   *Setting ground control points, the active point is shown in green.*
+   Setting ground control points.
+   The active point is shown in green.
 
 The Ground Control Points pane provides a way to select and manage the added GCPs.  The pane lists all added points and allows the user to optionally assign a name to each.  The GCP
 pane also shows the geodetic coordinates of the active point, and these points can be copied to the clipboard in different formats using the copy location button
@@ -254,7 +255,7 @@ SketchUp.
 .. figure:: /images/export_gcps.png
    :align: center
 
-   *Export the ground control points.*
+   Export the ground control points.
 
 Set 3D Region of Interest
 ===========================
@@ -274,7 +275,8 @@ scale the box uniformily about its origin.  Note that the ground plane grid will
 .. figure:: /images/default_3D_bounding_box.png
    :align: center
 
-   *The default 3D bounding box is fit to the sparse landmarks and is often bigger than needed.*
+   The default 3D bounding box is fit to the sparse landmarks
+   and is often bigger than needed.
 
 A good practice is to set the bottom of the ROI box just below the ground and the top just above the tallest part of the structure.  Likewise, set the sides to be just a bit outside
 the object of interest.  It may be difficult to determine the bounds accurately from the sparse landmarks.  A good strategy is to start with a slightly larger guess, then use the
@@ -286,7 +288,7 @@ To reset the ROI to the initial estimated bounding box, use the *Reset Region of
 .. figure:: /images/tighter_bounding_box.png
    :align: center
 
-   *Setting a tighter bounding box around one structure of interest.*
+   Setting a tighter bounding box around one structure of interest.
 
 Batch Compute Depth Maps
 ==========================
@@ -301,7 +303,7 @@ nearby positions are required. By default, the algorithm uses the ten frames bef
 .. figure:: /images/compute_dense_depth_map.png
    :align: center
 
-   *Compute dense depth maps on key frames*
+   Compute dense depth maps on key frames.
 
 The results of depth map estimation are shown in two ways.  In the world view the depth maps are shown as a dense colored point cloud in which every image pixel is back projected
 into 3D at the estimated depth.  Use the Depth Map button ( |depth_map_button| ) to toggle depth point cloud visibility.  The second way depth maps are visualized is as a depth image
@@ -311,7 +313,7 @@ in the Depth Map View.  Here each pixel is color coded by depth and the color ma
    :align: center
 
 
-   *Results of depth map computation*
+   Results of depth map computation.
 
 Fuse Depth Maps
 =================
@@ -325,7 +327,7 @@ the volume.
 .. figure:: /images/fuse_depth_maps.png
    :align: center
 
-   *Fuse the depth maps into a consistent mesh.*
+   Fuse the depth maps into a consistent mesh.
 
 To toggle the view of the fused mesh, press the Volume Display button ( |volume_display_button| ) above the 3D World View. The surface mesh can be fine-tuned if desired by adjusting
 the surface threshold in the drop-down menu under the Volume Display button.  Setting the threshold slightly positive (e.g. 0.5) often helps to remove unwanted outlier surfaces that
@@ -334,7 +336,7 @@ tend to appear in areas with only a few views.
 .. figure:: /images/fused_mesh.png
    :align: center
 
-   *View the fused mesh, adjust surface threshold if desired.*
+   View the fused mesh, adjust surface threshold if desired.
 
 Colorize Mesh
 ==============
@@ -350,17 +352,18 @@ The *Normals* option colors the mesh by surface normal direction, and the *NbPro
 .. figure:: /images/mesh_colorization_menu.png
    :align: center
 
-   *The mesh colorization menu options.*
+   The mesh colorization menu options.
 
 .. figure:: /images/colored_fused_mesh.png
    :align: center
 
-   *A fused mesh colored by the mean of multiple frames.*
+   A fused mesh colored by the mean of multiple frames.
 
 .. figure:: /images/mesh_colored_by_views.png
    :align: center
 
-   *A fused mesh colored by the number of views that see each part of the surface.*
+   A fused mesh colored by the number of views
+   that see each part of the surface.
 
 Export Data
 ============
@@ -373,12 +376,12 @@ currently set.
 .. figure:: /images/save_colorized_mesh.png
    :align: center
 
-   *Save a colorized mesh as a PLY, LAS, or VTP file.*
+   Save a colorized mesh as a PLY, LAS, or VTP file.
 
 .. figure:: /images/save_mesh_as_LAS.png
    :align: center
 
-   *Change the Save as type to export as LAS.*
+   Change the Save as type to export as LAS.
 
 To export the active 2.5D depth map for use in other software, use the *File->Export->Depth Map* menu item.  This will provide a file dialog to save the model as an RGB colored point
 cloud in the standard PLY or LAS file formats.
@@ -386,7 +389,7 @@ cloud in the standard PLY or LAS file formats.
 .. figure:: /images/save_depth_map.png
    :align: center
 
-   *Save a computed depth map as a point cloud in PLY or LAS formats.*
+   Save a computed depth map as a point cloud in PLY or LAS formats.
 
 Measurement Tool
 ==================
@@ -400,7 +403,7 @@ location when playing back the video then the 3D coordinates are correct.
 .. figure:: /images/measure_building_height.png
    :align: center
 
-   *Measuring a building height with the measurement tool.*
+   Measuring a building height with the measurement tool.
 
 When measuring it is sometimes convenient to constraint the measurements to the horizontal or vertical directions.  After the initial ruler is placed in the scene, click and drag one
 end point.  If the Z key is held on the keyboard the moving point will be constrained to lie on a vertical axis through the point at the other end of the ruler.  If either the X or Y

--- a/doc/workflows.rst
+++ b/doc/workflows.rst
@@ -23,7 +23,7 @@ represented, but this video has only platform orientation and is missing sensor 
 .. figure:: /images/inspect_metadata.png
    :align: center
 
-   *Inspecting Metadata geometrically and with the metadata viewer pane.*
+   Inspecting Metadata geometrically and with the metadata viewer pane.
 
 To inspect the metadata, follow the instructions for opening a video.  There is no need to create a project file if no further processing is anticipated.  When a video is opened it
 is automatically scanned for all metadata to build the 3D representation of the cameras.  Scanning a video for metadata may take several seconds or even minutes for very large
@@ -36,12 +36,12 @@ The goal of this workflow is to estimate accurate camera models for keyframes in
 interface to build 3D models in SketchUp by drawing directly on the images.  The SketchUp workflow is described in a separate document.  This document describes how to use
 TeleSculptor to produce the data that will be loaded into SketchUp.  The processing steps are as follows
 
-1.	Create a New Project
-2.	Import a Video
-3.	Track Features
-4.	Estimate Cameras/Landmarks
-5.	Save Frames
-6.	Set Ground Control Points
+1. Create a New Project
+2. Import a Video
+3. Track Features
+4. Estimate Cameras/Landmarks
+5. Save Frames
+6. Set Ground Control Points
 
 Dense Automated 3D Models
 ==========================


### PR DESCRIPTION
Remove unnecessary explicit emphasis markup from figure captions. Remove some leftover cruft and reduce warnings. Make the default text alignment 'justified'. Overhaul the "Manual Camera Calibration" section.

The updated version covers the same concepts but has been significantly rewritten using new features and to improve grammar and tone. Styling is introduced for menus, actions, shortcuts, and inline mathematical notation, and custom parsing to easily reference icons (the main feature from the old documentation system) has been added.