### PR TITLE
More doc updates

### DIFF
--- a/doc/cameracalibration.rst
+++ b/doc/cameracalibration.rst
@@ -92,7 +92,7 @@ The relevant edit mode actions may be used at any time
 to switch between editing points in the camera or world views.
 
 Once six or more correspondences have been defined,
-the camera pose calibration process may be invoked
+the camera model calibration process may be invoked
 from the :menu:`Compute Camera` action located in the drop-down
 associated with :action:`location Edit Registration Points`.
 Check the Log Viewer for the re-projection error
@@ -114,10 +114,10 @@ projected onto the camera image.
 
 Repeat this process on additional frames.
 Point locations may be adjusted as needed, as described above,
-to refine the camera pose calibration.
+to refine the camera model calibration.
 Camera calibrations may be refined at any time;
-it is not necessary to "finalize" one camera pose
-before calibrating additional camera poses.
+it is not necessary to "finalize" one camera model
+before calibrating additional camera models.
 
 When satisfied,
 :menu:`File` |rarrow| :menu:`Export` |rarrow| :menu:`KRTD Cameras...`

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -15,10 +15,10 @@ Frame:
   the term "frame" is used to indicate
   instances where the pose may not yet be known.
 
-Camera:
-  In TeleSculptor, a camera
-  refers primarily to the model
-  which describes the intrinsic and extrinsic parameters
+Camera Model:
+  In TeleSculptor, a camera model
+  (often shortened to "camera")
+  describes the intrinsic and extrinsic parameters
   of a camera at a given frame.
   Intrinsic parameters include focal length and lens distortion.
   Extrinsic parameters are the camera pose |--| orientation and position.
@@ -35,12 +35,14 @@ Camera:
   indicates which direction is "up" in the image.
   The pyramid visualizes the field of view of the camera.
 
-
 Feature:
-  A feature is a location that corresponds to a salient point in an image.
-  Features have enough visual texture that they can be reliably localized
+  A feature describes a salient point in an image.
+  Features have enough visual texture
+  that they can be reliably localized
   in images across time.
-  Features are also known as interest points or corner points.
+  Features are also known
+  as interest points
+  or corner points.
 
 Track:
   A (feature) track is a collection of correlated features;
@@ -53,31 +55,33 @@ Landmark:
   gave rise to an observed feature track.
 
 Residual:
-  A residual, in general, is the difference between an observed value and an
-  estimated value\ [#er]_. In TeleSculptor, the observed value is typically a
-  detected feature point, and the estimated value is the projection of its
-  corresponding landmark into the image.
+  A residual, in general, is the difference
+  between an observed value and an estimated value\ [#er]_.
+  In TeleSculptor, the observed value
+  is typically a detected feature point,
+  and the estimated value is the projection
+  of its corresponding landmark into the image.
 
 Ground Control Point (GCP):
   A |gcp| is a 3D point
   that is manually placed in the scene by a user.
-  Ground control points are often attached 
+  Ground control points are often attached
   to an identifiable location from a reference image or map.
   The user can assign the true geodetic location
   (latitude, longitude, elevation) to a |gcp|,
-  and that |gcp| can then serve as a constraint 
+  and that |gcp| can then serve as a constraint
   when geo-registering the model.
 
 Camera Registration Point (CRP):
-  A |crp| is a 2D point 
+  A |crp| is a 2D point
   that is manually placed by the user
   in one or more frame images.
   Camera registration points are associated with a |gcp|
   and can tie that |gcp| to multiple images,
   even when no camera model has been estimated.
-  While a |gcp| is the manually placed version of a landmark,
+  Whereas a |gcp| is the manually placed version of a landmark,
   a |crp| is the manually placed version of a feature track.
-  A collection of |crp|\ s can be used 
+  A collection of |crp|\ s can be used
   to manually estimate a camera model
   when automated feature matching is not possible.
 

--- a/doc/interface.rst
+++ b/doc/interface.rst
@@ -57,7 +57,7 @@ Camera Selection:
 Camera View:
   Shows the imagery from the current frame,
   along with various two dimensional geometry.
-  If a camera pose is available,
+  If a camera model is available,
   also shows three dimensional geometry
   mapped into the camera's point of view,
   as well as estimation residuals.
@@ -175,7 +175,7 @@ Tool Bar
 :icon:`image` Show Camera Frame Image
   Toggles visibility of the frame image
   projected onto the ground plane
-  (if an associated camera pose is available).
+  (if an associated camera model is available).
   The associated pop-up allows the opacity of the same to be adjusted.
 
 :icon:`camera` Show Cameras
@@ -337,7 +337,8 @@ median color,
 surface normal,
 and number of observations.
 
-.. TODO move following to a different page with also CRP documentation
+.. TODO move following to a different page with also CRP documentation,
+        and probably consolidate with cameracalibration.rst
 
 Editing Ground Control Points
 -----------------------------
@@ -426,10 +427,12 @@ Tool Bar
   The associated pop-up
   allows the color of the displayed residuals to be changed.
 
+.. TODO fix following ref when content is moved
+
 :icon:`location` Edit Camera Registration Points
   Toggles editing of |crp|\ s.
   See :doc:`cameracalibration` for details.
-  The associated pop-up 
+  The associated pop-up
   allows computing a camera model
   on the current frame using |crp|\ s.
   The keyboard shortcut is :shortcut:`Ctrl+R`.
@@ -441,8 +444,9 @@ In addition to active feature points,
 which have all the options described in `Point Options`_,
 the position of feature points on adjacent frames
 may also be displayed by enabling :action:`- Trails`.
-For image collections where camera poses adjacent in the camera list
-are also spatially similar
+For image collections where frames
+adjacent in the frame list
+also have spatially similar camera poses
 (especially when using consecutive video frames as input),
 these may be useful as an additional means of visualizing camera motion.
 


### PR DESCRIPTION
Further update glossary, restoring the use of something other than just "camera". After some discussion, we agreed that "camera modal" works better; update other places that were using "pose" where "model" is more correct (but note that some uses of "pose" remain more correct than "model"). Change action text on 'Edit CRPs' to match the documentation. Also, remove some inappropriate whitespace, fix some line wrapping that was missed in earlier commits, and further tweak some of the bits in the glossary.