### PR TITLE
Add "Use GPU" option

### DIFF
--- a/config/gui_integrate_depth_maps.conf
+++ b/config/gui_integrate_depth_maps.conf
@@ -1,49 +1,9 @@
-# Default configuration for the "integrate_depth_maps" algorithm used in the GUI
+# Default configuration for the CPU "integrate_depth_maps" algorithm used in the GUI
 
 block integrate_depth_maps
-	type = cuda
-	block cuda
-		ray_potential_thickness = 3.0
-		ray_potential_rho = 1.0
-		ray_potential_eta = 1.0
-		ray_potential_delta = 10.0
-		grid_spacing = 1.0 1.0 1.0
-		voxel_spacing_factor = 2.0
+	type = mvg
+	block mvg
+		include integrate_depth_maps_common.conf
 	endblock
 endblock
-
-##############################################################################
-#     Truncated Signed Distance Function (TSDF) Parameter Description        #
-##############################################################################
-# Eta is a percentage of rho ( 0 < Eta < 1)
-# Delta has to be superior to Thick
-#
-#                     'real distance' - 'depth value'
-#                                     |
-#                                     |
-#                                     |         ---------------  Rho
-#                                     |        /|             |
-#                                     |       /               |
-#                                     |      /  |             |
-#                                     |     /                 |
-#                                     |    /    |             |
-#                                     |   /                   |
-#                                     |  /      |             |
-#                                     | /                     |
-#                                     |/        |             |______________
-#----------------------------------------------------------------------------
-#                                    /
-#                                   /
-#                                  /
-#--------------  Eta*rho          /
-#             |                  /
-#             |                 /
-#             |                /
-#             |               /
-#             |              /
-#             ---------------
-#                            <--------->
-#                               Thick
-#             <----------------------->
-#                        Delta
 

--- a/config/gui_integrate_depth_maps_gpu.conf
+++ b/config/gui_integrate_depth_maps_gpu.conf
@@ -1,0 +1,9 @@
+# Default configuration for the GPU "integrate_depth_maps" algorithm used in the GUI
+
+block integrate_depth_maps
+	type = cuda
+	block cuda
+		include integrate_depth_maps_common.conf
+	endblock
+endblock
+

--- a/config/integrate_depth_maps_common.conf
+++ b/config/integrate_depth_maps_common.conf
@@ -1,0 +1,45 @@
+# Default configuration for the "integrate_depth_maps" algorithm used in the GUI
+# The same parameters are used for both CPU (mvg) and GPU (cuda) versions
+
+ray_potential_thickness = 3.0
+ray_potential_rho = 1.0
+ray_potential_eta = 1.0
+ray_potential_delta = 10.0
+grid_spacing = 1.0 1.0 1.0
+voxel_spacing_factor = 2.0
+
+##############################################################################
+#     Truncated Signed Distance Function (TSDF) Parameter Description        #
+##############################################################################
+# Eta is a percentage of rho ( 0 < Eta < 1)
+# Delta has to be superior to Thick
+#
+#                     'real distance' - 'depth value'
+#                                     |
+#                                     |
+#                                     |         ---------------  Rho
+#                                     |        /|             |
+#                                     |       /               |
+#                                     |      /  |             |
+#                                     |     /                 |
+#                                     |    /    |             |
+#                                     |   /                   |
+#                                     |  /      |             |
+#                                     | /                     |
+#                                     |/        |             |______________
+#----------------------------------------------------------------------------
+#                                    /
+#                                   /
+#                                  /
+#--------------  Eta*rho          /
+#             |                  /
+#             |                 /
+#             |                /
+#             |               /
+#             |              /
+#             ---------------
+#                            <--------->
+#                               Thick
+#             <----------------------->
+#                        Delta
+

--- a/doc/computeoptions.rst
+++ b/doc/computeoptions.rst
@@ -36,9 +36,12 @@ one.
 Use GPU
 =========
 
-TeleSculptor has historically used a CUDA implementation of the depth map
-fusion algorithm.  An Nvidia GPU is required for CUDA support, so some systems
-were not able to run this step of the pipeline.  A CPU version of this
-algorithm is now available and this option determines whether to use the CPU
-implementation or the GPU implementation.  Both should give the same results,
-but the GPU impementation is faster when suitable hardware is available.
+Some TeleSculptor algorithms
+(currently, depth map fusion)
+are able to use CUDA to improve performance.
+However, this requires an NVIDIA GPU
+with sufficient GPU RAM.
+Disabling this option instructs TeleSculptor
+to rely solely on the CPU.
+This is slower, but should give the same results
+and may be used if a suitable GPU is not available.

--- a/doc/computeoptions.rst
+++ b/doc/computeoptions.rst
@@ -32,3 +32,13 @@ TeleSculptor automatically selects a local origin near the centroid of the data 
 algorithms that origin point is recalculated and may change.  In some cases, there are benefits to specifying the geographic origin to use and keeping it fixed, for example, forcing
 two data sets to share a common local origin for easier comparison.  Checking “Fix Geo-Origin” instructs TeleSculptor to keep the current geographic origin and not recalculate a new
 one.
+
+Use GPU
+=========
+
+TeleSculptor has historically used a CUDA implementation of the depth map
+fusion algorithm.  An Nvidia GPU is required for CUDA support, so some systems
+were not able to run this step of the pipeline.  A CPU version of this
+algorithm is now available and this option determines whether to use the CPU
+implementation or the GPU implementation.  Both should give the same results,
+but the GPU impementation is faster when suitable hardware is available.

--- a/doc/interface.rst
+++ b/doc/interface.rst
@@ -922,8 +922,9 @@ Compute Menu |rarrow| Options
   such as comparing results across different data of the same location.
 
 :icon:`blank` Use GPU
-  If checked, this option will use a CUDA implementation of depth map fusion.
-  This requires an Nvidia GPU.
+  If checked, this option will use a CUDA implementation
+  of some algorithms (currently, depth map fusion).
+  This requires an NVIDIA GPU with sufficient GPU RAM.
   If unchecked, the CPU implementation will be used instead.
 
 .. _view-menu:

--- a/doc/interface.rst
+++ b/doc/interface.rst
@@ -921,6 +921,11 @@ Compute Menu |rarrow| Options
   to specify an origin and keep it fixed,
   such as comparing results across different data of the same location.
 
+:icon:`blank` Use GPU
+  If checked, this option will use a CUDA implementation of depth map fusion.
+  This requires an Nvidia GPU.
+  If unchecked, the CPU implementation will be used instead.
+
 .. _view-menu:
 
 View Menu

--- a/doc/release-notes/1.2.0.txt
+++ b/doc/release-notes/1.2.0.txt
@@ -13,6 +13,8 @@ registration points on frames.
 TeleSculptor v1.2.0 also builds on updated KWIVER v1.6.0 and Fletch v1.5.0,
 which provide upgraded third-party packages and improvements to algorithms.
 For example, TeleSculptor now uses VTK 9.0, OpenCV 4.5, and Qt 5.12.
+KWIVER now supports both CPU and GPU (CUDA) implementations for depth map
+fusion, and an option has been added to TeleSculptor to enable GPU use.
 While command line tools have been removed from TeleSculptor, it is now
 possible to reproduce the entire TeleSculptor processing chain from the
 command line using the *kwiver* command.  The command line workflow uses
@@ -66,6 +68,11 @@ TeleSculptor Application
 
  * Added keyboard shortcuts to change frames and to change the selected ground
    control point.
+
+ * Added an option to enable use of the GPU.  This specifically supports depth
+   map fusion for which both GPU and CPU implementations exist.  For the first
+   time, it is now possible to run TeleSculptor end-to-end without a
+   CUDA-enabled GPU.
 
 Tools
 

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1952,20 +1952,20 @@ void MainWindow::loadProject(QString const& path)
 
   auto oldSignalState = d->UI.menuComputeOptions->blockSignals(true);
 
-  bool ignore_metadata =
-    d->project->config->get_value<bool>("ignore_metadata", false);
+  bool ignore_metadata = d->project->config->get_value<bool>(
+    "ignore_metadata", d->UI.actionIgnoreMetadata->isChecked());
   d->UI.actionIgnoreMetadata->setChecked(ignore_metadata);
 
-  bool variable_lens =
-    d->project->config->get_value<bool>("variable_lens", false);
+  bool variable_lens = d->project->config->get_value<bool>(
+    "variable_lens", d->UI.actionVariableLens->isChecked());
   d->UI.actionVariableLens->setChecked(variable_lens);
 
-  bool fix_geo_origin =
-    d->project->config->get_value<bool>("fix_geo_origin", false);
+  bool fix_geo_origin = d->project->config->get_value<bool>(
+    "fix_geo_origin", d->UI.actionFixGeoOrigin->isChecked());
   d->UI.actionFixGeoOrigin->setChecked(fix_geo_origin);
 
-  bool use_gpu =
-    d->project->config->get_value<bool>("use_gpu", true);
+  bool use_gpu = d->project->config->get_value<bool>(
+    "use_gpu", d->UI.actionUseGPU->isChecked());
   d->UI.actionUseGPU->setChecked(use_gpu);
 
   d->UI.menuComputeOptions->blockSignals(oldSignalState);

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1590,6 +1590,8 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
           this, &MainWindow::setVariableLens);
   connect(d->UI.actionFixGeoOrigin, &QAction::toggled,
           this, &MainWindow::setFixGeoOrigin);
+  connect(d->UI.actionUseGPU, &QAction::toggled,
+          this, &MainWindow::setUseGPU);
 
   connect(d->UI.actionSetBackgroundColor, &QAction::triggered,
           this, &MainWindow::setViewBackroundColor);
@@ -1951,6 +1953,10 @@ void MainWindow::loadProject(QString const& path)
   bool fix_geo_origin =
     d->project->config->get_value<bool>("fix_geo_origin", false);
   d->UI.actionFixGeoOrigin->setChecked(fix_geo_origin);
+
+  bool use_gpu =
+    d->project->config->get_value<bool>("use_gpu", true);
+  d->UI.actionUseGPU->setChecked(use_gpu);
 
   d->UI.menuComputeOptions->blockSignals(oldSignalState);
 
@@ -3240,6 +3246,12 @@ void MainWindow::setVariableLens(bool state)
 void MainWindow::setFixGeoOrigin(bool state)
 {
   setComputeOption("fix_geo_origin", state);
+}
+
+//-----------------------------------------------------------------------------
+void MainWindow::setUseGPU(bool state)
+{
+  setComputeOption("use_gpu", state);
 }
 
 //-----------------------------------------------------------------------------

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1916,6 +1916,12 @@ void MainWindow::newProject()
       saveGeoOrigin(d->project->geoOriginFile);
     }
 
+    if (!d->UI.actionUseGPU->isEnabled())
+    {
+      // explicity disable GPU in the project if there is no option for it
+      d->project->config->set_value("use_gpu", "false");
+    }
+
     d->project->write();
   }
 
@@ -1967,6 +1973,12 @@ void MainWindow::loadProject(QString const& path)
   bool use_gpu = d->project->config->get_value<bool>(
     "use_gpu", d->UI.actionUseGPU->isChecked());
   d->UI.actionUseGPU->setChecked(use_gpu);
+
+  if (!d->UI.actionUseGPU->isEnabled())
+  {
+    // explicity disable GPU in the project if there is no option for it
+    d->project->config->set_value("use_gpu", "false");
+  }
 
   d->UI.menuComputeOptions->blockSignals(oldSignalState);
 

--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -39,6 +39,7 @@
 #include <arrows/core/track_set_impl.h>
 #include <arrows/mvg/transform.h>
 #include "arrows/vtk/vtkKwiverCamera.h"
+#include <vital/algo/algorithm_factory.h>
 #include <vital/algo/estimate_similarity_transform.h>
 #include <vital/algo/resection_camera.h>
 #include <vital/algo/video_input.h>
@@ -1720,6 +1721,15 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
   // Unitil the bounding box is initialized, the bounds are going to be
   // [VTK_DOUBLE_MIN, VTK_DOUBLE_MAX] in all directions.
   d->UI.worldView->setROI(d->roi);
+
+  // check if the application has the CUDA plugin
+  bool has_cuda =
+    kwiver::vital::has_algorithm_impl_name("integrate_depth_maps", "cuda");
+  if (!has_cuda)
+  {
+    d->UI.actionUseGPU->setChecked(false);
+    d->UI.actionUseGPU->setEnabled(false);
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/gui/MainWindow.h
+++ b/gui/MainWindow.h
@@ -125,6 +125,7 @@ protected slots:
   void setIgnoreMetadata(bool);
   void setVariableLens(bool);
   void setFixGeoOrigin(bool);
+  void setUseGPU(bool);
 
 private:
   void acceptToolResults(std::shared_ptr<ToolData> data, bool isFinal);

--- a/gui/MainWindow.ui
+++ b/gui/MainWindow.ui
@@ -121,6 +121,7 @@
      <addaction name="actionIgnoreMetadata"/>
      <addaction name="actionVariableLens"/>
      <addaction name="actionFixGeoOrigin"/>
+     <addaction name="actionUseGPU"/>
     </widget>
     <addaction name="actionCancelComputation"/>
     <addaction name="separator"/>
@@ -619,6 +620,20 @@
    </property>
    <property name="toolTip">
     <string>Keep the origin of the local geospatial coordinates fixed.</string>
+   </property>
+  </action>
+  <action name="actionUseGPU">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Use GPU</string>
+   </property>
+   <property name="toolTip">
+    <string>Use CUDA to accelerate processing on the GPU </string>
    </property>
   </action>
   <action name="actionExportFusedMeshFrameColors">

--- a/gui/MainWindow.ui
+++ b/gui/MainWindow.ui
@@ -633,7 +633,7 @@
     <string>&amp;Use GPU</string>
    </property>
    <property name="toolTip">
-    <string>Use CUDA to accelerate processing on the GPU </string>
+    <string>Use CUDA to accelerate processing on the GPU.</string>
    </property>
   </action>
   <action name="actionExportFusedMeshFrameColors">

--- a/gui/tools/FuseDepthTool.cxx
+++ b/gui/tools/FuseDepthTool.cxx
@@ -94,8 +94,15 @@ bool FuseDepthTool::execute(QWidget* window)
       "This operation requires cameras");
     return false;
   }
+
+  std::string config_file = "gui_integrate_depth_maps.conf";
+  if (this->data()->config->get_value<bool>("use_gpu", true))
+  {
+    config_file = "gui_integrate_depth_maps_gpu.conf";
+  }
+
   // Load configuration
-  auto const config = readConfig("gui_integrate_depth_maps.conf");
+  auto const config = readConfig(config_file);
 
   // Check configuration
   if (!config)


### PR DESCRIPTION
Here is an option to manually switch between CPU and GPU usage algorithms.  Currently only for depth map fusion.  

TODO: I may update this to detect whether the CUDA module is loaded and disable this option if CUDA is not found.