### PR TITLE
Fixed a crash when fusing depth after a mesh has been loaded from disk

### DIFF
--- a/gui/VolumeOptions.cxx
+++ b/gui/VolumeOptions.cxx
@@ -293,6 +293,12 @@ bool VolumeOptions::isColorOptionsEnabled()
   return  d->UI.comboBoxColorizeSurface->currentIndex() == IMAGE_COLOR;
 }
 
+//-----------------------------------------------------------------------------
+void VolumeOptions::disableOriginalColor()
+{
+  QTE_D();
+  d->UI.comboBoxColorizeSurface->removeItem(ORIGINAL_COLOR);
+}
 
 //-----------------------------------------------------------------------------
 bool VolumeOptions::isArrayValidForColoring(vtkDataArray* a, bool& mapScalars)

--- a/gui/VolumeOptions.h
+++ b/gui/VolumeOptions.h
@@ -60,6 +60,7 @@ public:
   void setSurfaceColoringMode(SurfaceColor surfaceColor, bool blockSignals = false);
   void setOriginalColorArray(vtkDataArray* dataArray);
   bool isColorOptionsEnabled();
+  void disableOriginalColor();
 
   static bool isArrayValidForColoring(vtkDataArray* a, bool& mapScalars);
 

--- a/gui/WorldView.cxx
+++ b/gui/WorldView.cxx
@@ -937,6 +937,8 @@ void WorldView::setVolume(vtkSmartPointer<vtkImageData> volume)
   d->volumeActor->SetVisibility(true);
   d->volumeOptions->setActor(d->volumeActor);
   d->volumeOptions->setEnabled(true);
+  d->volumeOptions->setSurfaceColoringMode(VolumeOptions::NO_COLOR);
+  d->volumeOptions->disableOriginalColor();
 
   emit this->volumeEnabled(true);
   emit this->fusedMeshEnabled(true);


### PR DESCRIPTION
We need to switch back to "no color" and disable the "original color" option
when a fused volume mesh replaces a mesh that was loaded from a file.