### PR TITLE
Added a hack to show the Options menu on MacOS

### DIFF
--- a/gui/MainWindow.cxx
+++ b/gui/MainWindow.cxx
@@ -1499,6 +1499,11 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags flags)
     std::bind(&MainWindowPrivate::handleLogMessage, d, _1, _2, _3, _4);
   kv::kwiver_logger::set_global_callback(cb);
 
+  // Work around issue where "Options" menu will not display on MacOS
+#ifdef __APPLE__
+  d->UI.menuComputeOptions->setTitle("0ptions");
+#endif
+
   d->toolMenu = d->UI.menuCompute;
   d->toolSeparator =
     d->UI.menuCompute->insertSeparator(d->UI.actionCancelComputation);


### PR DESCRIPTION
This is an ugly hack, but I'm not sure of a better way to make this work.
If on Apple then replace the menu title "Options" with "0ptions" (note the zero instead of O).
This seems to work and visually not that noticeable, but we should find a better fix at some point.