### PR TITLE
Updated git ssh clone to comply with new standards

### DIFF
--- a/CMake/telesculptor-external-fletch.cmake
+++ b/CMake/telesculptor-external-fletch.cmake
@@ -48,7 +48,7 @@ endif()
 
 ExternalProject_Add(fletch
   PREFIX ${TELESCULPTOR_BINARY_DIR}
-  GIT_REPOSITORY "git://github.com/Kitware/fletch.git"
+  GIT_REPOSITORY "https://github.com/Kitware/fletch.git"
   GIT_TAG 94870a290a06db845e80816863bb6d1b9cb12085
   #GIT_SHALLOW 1
   SOURCE_DIR ${TELESCULPTOR_EXTERNAL_DIR}/fletch


### PR DESCRIPTION
Bugfix for errors cloning fletch. Github released these changes https://github.blog/2021-09-01-improving-git-protocol-security-github/ which finalized a breaking change on March 15, 2022.